### PR TITLE
in settings, implement pressing Escape key to exit settings

### DIFF
--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -172,10 +172,20 @@ export default {
           this.update_available = true
       })
     }
+
+    window.addEventListener('keydown', this.handleKeyDown)
+  },
+  unmounted() {
+    window.removeEventListener('keydown', this.handleKeyDown)
   },
   methods: {
     open_external(link: string) {
       window.open(link, '_blank')
+    },
+    handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        this.$router.push({ path: '/' })
+      }
     },
   },
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This implementation allows the user to press the Escape key to route to Home when the Settings component is mounted.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other
