### PR TITLE
in speech-to-text settings, fix the jumping of pin icons

### DIFF
--- a/src/components/settings/STT.vue
+++ b/src/components/settings/STT.vue
@@ -251,11 +251,11 @@ export default {
   width: 100%;
 }
 
-.language-card .pin-icon-not-pinned {
+.language-card .pin-icon-not-pinned:before {
   display: none !important;
 }
 
-.language-card:hover .pin-icon-not-pinned {
+.language-card:hover .pin-icon-not-pinned:before {
   display: inline-block !important;
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description <!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This fixes a graphical error that is caused by selecting the wrong elements in CSS.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <video src="https://github.com/naeruru/mimiuchi/assets/117558001/d66d12da-0e49-4483-8da7-2c17efb58066" controls></video>
        </td>
        <td>
            <video src="https://github.com/naeruru/mimiuchi/assets/117558001/29cd66ff-1599-4422-9caf-7fded29e3a36" controls></video>
        </td>
    </tr>
</table>

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
