### PR TITLE
revise word replace

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -87,10 +87,6 @@ export default {
     this.settingsStore.$subscribe((language, state) => {
       this.$i18n.locale = this.settingsStore.language
     })
-
-    // temp word replace upgrade
-    this.wordReplaceStore.update()
-    console.log(this.wordReplaceStore.word_replacements)
   },
   created() {
     if (this.is_electron())

--- a/src/App.vue
+++ b/src/App.vue
@@ -72,6 +72,7 @@ export default {
       settingsStore,
       connectionStore,
       is_electron,
+      wordReplaceStore,
     }
   },
   unmounted() {
@@ -86,6 +87,10 @@ export default {
     this.settingsStore.$subscribe((language, state) => {
       this.$i18n.locale = this.settingsStore.language
     })
+
+    // temp word replace upgrade
+    this.wordReplaceStore.update()
+    console.log(this.wordReplaceStore.word_replacements)
   },
   created() {
     if (this.is_electron())

--- a/src/components/settings/WordReplace.vue
+++ b/src/components/settings/WordReplace.vue
@@ -98,8 +98,13 @@ export default {
     this.wordReplaceStore.word_replacements_lowercase = {}
 
     Object.keys(this.wordReplaceStore.word_replacements).forEach(key => {
-      const keyLowerCase = key.toLowerCase();
-      this.wordReplaceStore.word_replacements_lowercase[keyLowerCase] = this.wordReplaceStore.word_replacements[key];
+      const keyLowerCase = key.toLowerCase()
+
+      // First-come, first-served.
+      // For example, the replacement keys "Hello" and "hello" are both transformed to lowercase as "hello".
+      // When ordered by locale, their order is ["hello", "Hello"]. The replacement entry for "hello" will be used in case-insensitive replacements.
+      if (!this.wordReplaceStore.word_replacements_lowercase[keyLowerCase])
+        this.wordReplaceStore.word_replacements_lowercase[keyLowerCase] = this.wordReplaceStore.word_replacements[key]
     })
   },
   mounted() {

--- a/src/components/settings/WordReplace.vue
+++ b/src/components/settings/WordReplace.vue
@@ -58,17 +58,8 @@ export default {
   unmounted() {
     this.wordReplaceStore.word_replacements = {}
     this.replacements
-      .sort((a, b) => {
-        // Sort keys by string length: longer strings to shorter strings.
-        const comparison = b.replacing.length - a.replacing.length;
-
-        // If the lengths are equal, sort keys by locale (e.g., alphabetical sort). This is cosmetic.
-        if (comparison === 0) {
-          return a.replacing.localeCompare(b.replacing);
-        }
-
-        return comparison;
-      })
+      .sort((a, b) => a.replacing.localeCompare(b.replacing)) // Sort keys by locale (e.g., alphabetical sort). This is cosmetic.
+      .sort((a, b) => b.replacing.length - a.replacing.length) // Sort keys by string length: longer strings to shorter strings.
       .forEach((entry) => {
         this.wordReplaceStore.word_replacements[entry.replacing] = entry.replacement
     })

--- a/src/components/settings/WordReplace.vue
+++ b/src/components/settings/WordReplace.vue
@@ -61,7 +61,7 @@ export default {
       .sort((a, b) => a.replacing.localeCompare(b.replacing)) // Sort keys by locale (e.g., alphabetical sort). This is cosmetic.
       .sort((a, b) => b.replacing.length - a.replacing.length) // Sort keys by string length: longer strings to shorter strings.
       .forEach((entry) => {
-        this.wordReplaceStore.word_replacements[entry.replacing] = entry.replacement
+        this.wordReplaceStore.word_replacements[entry.replacing.toLowerCase()] = entry.replacement
     })
   },
   mounted() {

--- a/src/components/settings/WordReplace.vue
+++ b/src/components/settings/WordReplace.vue
@@ -57,8 +57,11 @@ export default {
   }),
   unmounted() {
     this.wordReplaceStore.word_replacements = {}
-    this.replacements.forEach((entry) => {
-      this.wordReplaceStore.word_replacements[entry.replacing] = entry.replacement
+    this.replacements
+      .sort((a, b) => a.replacing.localeCompare(b.replacing)) // Sort keys by locale (e.g., alphabetical sort). This is cosmetic.
+      .sort((a, b) => b.replacing.length - a.replacing.length) // Sort keys by string length: longer strings to shorter strings.
+      .forEach((entry) => {
+        this.wordReplaceStore.word_replacements[entry.replacing] = entry.replacement
     })
   },
   mounted() {

--- a/src/components/settings/WordReplace.vue
+++ b/src/components/settings/WordReplace.vue
@@ -58,7 +58,7 @@ export default {
   unmounted() {
     this.wordReplaceStore.word_replacements = {}
     this.replacements.forEach((entry) => {
-      this.wordReplaceStore.word_replacements[entry.replacing.toLowerCase()] = entry.replacement
+      this.wordReplaceStore.word_replacements[entry.replacing] = entry.replacement
     })
   },
   mounted() {

--- a/src/components/settings/WordReplace.vue
+++ b/src/components/settings/WordReplace.vue
@@ -92,7 +92,10 @@ export default {
       .sort((a, b) => a.replacing.localeCompare(b.replacing)) // Sort keys by locale (e.g., alphabetical sort). This is cosmetic.
       .sort((a, b) => b.replacing.length - a.replacing.length) // Sort keys by string length: longer strings to shorter strings.
       .forEach((entry) => {
-        this.wordReplaceStore.word_replacements[entry.replacing] = entry.replacement
+        this.wordReplaceStore.word_replacements[entry.replacing.toLowerCase()] = {
+          replace: entry.replacing,
+          replacement: entry.replacement
+        }
       })
 
     this.wordReplaceStore.word_replacements_lowercase = {}
@@ -108,9 +111,9 @@ export default {
     })
   },
   mounted() {
-    this.replacements = Object.entries(this.wordReplaceStore.word_replacements).map(([replacing, replacement]) => ({
-      replacing,
-      replacement,
+    this.replacements = Object.entries(this.wordReplaceStore.word_replacements).map(([_, obj]) => ({
+      replacing: obj.replace,
+      replacement: obj.replacement,
     }))
     // console.log(this.replacements)
   },

--- a/src/components/settings/WordReplace.vue
+++ b/src/components/settings/WordReplace.vue
@@ -87,11 +87,19 @@ export default {
   }),
   unmounted() {
     this.wordReplaceStore.word_replacements = {}
+
     this.replacements
       .sort((a, b) => a.replacing.localeCompare(b.replacing)) // Sort keys by locale (e.g., alphabetical sort). This is cosmetic.
       .sort((a, b) => b.replacing.length - a.replacing.length) // Sort keys by string length: longer strings to shorter strings.
       .forEach((entry) => {
-        this.wordReplaceStore.word_replacements[entry.replacing.toLowerCase()] = entry.replacement
+        this.wordReplaceStore.word_replacements[entry.replacing] = entry.replacement
+    })
+
+    this.wordReplaceStore.word_replacements_lowercase = {}
+
+    Object.keys(this.wordReplaceStore.word_replacements).forEach(key => {
+      const keyLowerCase = key.toLowerCase();
+      this.wordReplaceStore.word_replacements_lowercase[keyLowerCase] = this.wordReplaceStore.word_replacements[key];
     })
   },
   mounted() {

--- a/src/components/settings/WordReplace.vue
+++ b/src/components/settings/WordReplace.vue
@@ -14,6 +14,36 @@
           </template>
         </v-list-item>
       </v-card>
+      <v-row class="mt-6">
+        <v-col :cols="12" :sm="6">
+          <v-card flat>
+            <v-list-item :title="$t('settings.word_replace.match_whole_word')">
+              <template #append>
+                <v-switch
+                  v-model="wordReplaceStore.match_whole_word"
+                  color="primary"
+                  hide-details
+                  inset
+                />
+              </template>
+            </v-list-item>
+          </v-card>
+        </v-col>
+        <v-col :cols="12" :sm="6">
+          <v-card flat>
+            <v-list-item :title="$t('settings.word_replace.match_case')">
+              <template #append>
+                <v-switch
+                  v-model="wordReplaceStore.match_case"
+                  color="primary"
+                  hide-details
+                  inset
+                />
+              </template>
+            </v-list-item>
+          </v-card>
+        </v-col>
+      </v-row>
       <div v-if="replacements.length" class="mt-6">
         <v-row v-for="(replacement, i) in replacements">
           <v-col :cols="12" :sm="6">

--- a/src/components/settings/WordReplace.vue
+++ b/src/components/settings/WordReplace.vue
@@ -46,10 +46,10 @@
       </v-row>
       <div v-if="replacements.length" class="mt-6">
         <v-row v-for="(replacement, i) in replacements">
-          <v-col :cols="12" :sm="6">
-            <v-text-field v-model="replacement.replacing" :label="$t('settings.word_replace.replacing')" append-icon="mdi-arrow-right-bold" hide-details />
+          <v-col :cols="12" :sm="6" class="pt-1 pb-0">
+            <v-text-field v-model="replacement.replacing" :label="$t('settings.word_replace.replacing')" :rules="[exists]" append-icon="mdi-arrow-right-bold" />
           </v-col>
-          <v-col :cols="10" :sm="6">
+          <v-col :cols="10" :sm="6" class="pt-1 pb-0">
             <v-text-field v-model="replacement.replacement" :label="$t('settings.word_replace.replacement')" hide-details>
               <template #append>
                 <v-btn size="x-small" color="red" icon="mdi-minus" @click="remove_entry(i)" />
@@ -92,10 +92,7 @@ export default {
       .sort((a, b) => a.replacing.localeCompare(b.replacing)) // Sort keys by locale (e.g., alphabetical sort). This is cosmetic.
       .sort((a, b) => b.replacing.length - a.replacing.length) // Sort keys by string length: longer strings to shorter strings.
       .forEach((entry) => {
-        this.wordReplaceStore.word_replacements[entry.replacing.toLowerCase()] = {
-          replace: entry.replacing,
-          replacement: entry.replacement
-        }
+        this.wordReplaceStore.word_replacements[entry.replacing] = entry.replacement
       })
 
     this.wordReplaceStore.word_replacements_lowercase = {}
@@ -111,15 +108,13 @@ export default {
     })
   },
   mounted() {
-    this.replacements = Object.entries(this.wordReplaceStore.word_replacements).map(([_, obj]) => ({
-      replacing: obj.replace,
-      replacement: obj.replacement,
+    this.replacements = Object.entries(this.wordReplaceStore.word_replacements).map(([replacing, replacement]) => ({
+      replacing,
+      replacement,
     }))
-    // console.log(this.replacements)
   },
   methods: {
     add_entry() {
-      // this.wordReplaceStore.word_replacements[""] = ""
       this.replacements.push({
         replacing: '',
         replacement: '',
@@ -127,7 +122,9 @@ export default {
     },
     remove_entry(i: number) {
       this.replacements.splice(i, 1)
-      // delete this.wordReplaceStore.word_replacements[this.replacement_list[i].replacing]
+    },
+    exists(value: string) {
+      return !value || this.replacements.filter((e: any) => value === e.replacing).length < 2 || `${value} already exists`
     },
   },
 }

--- a/src/components/settings/WordReplace.vue
+++ b/src/components/settings/WordReplace.vue
@@ -93,11 +93,11 @@ export default {
       .sort((a, b) => b.replacing.length - a.replacing.length) // Sort keys by string length: longer strings to shorter strings.
       .forEach((entry) => {
         this.wordReplaceStore.word_replacements[entry.replacing] = entry.replacement
-    })
+      })
 
     this.wordReplaceStore.word_replacements_lowercase = {}
 
-    Object.keys(this.wordReplaceStore.word_replacements).forEach(key => {
+    Object.keys(this.wordReplaceStore.word_replacements).forEach((key) => {
       const keyLowerCase = key.toLowerCase()
 
       // First-come, first-served.

--- a/src/components/settings/WordReplace.vue
+++ b/src/components/settings/WordReplace.vue
@@ -58,8 +58,17 @@ export default {
   unmounted() {
     this.wordReplaceStore.word_replacements = {}
     this.replacements
-      .sort((a, b) => a.replacing.localeCompare(b.replacing)) // Sort keys by locale (e.g., alphabetical sort). This is cosmetic.
-      .sort((a, b) => b.replacing.length - a.replacing.length) // Sort keys by string length: longer strings to shorter strings.
+      .sort((a, b) => {
+        // Sort keys by string length: longer strings to shorter strings.
+        const comparison = b.replacing.length - a.replacing.length;
+
+        // If the lengths are equal, sort keys by locale (e.g., alphabetical sort). This is cosmetic.
+        if (comparison === 0) {
+          return a.replacing.localeCompare(b.replacing);
+        }
+
+        return comparison;
+      })
       .forEach((entry) => {
         this.wordReplaceStore.word_replacements[entry.replacing] = entry.replacement
     })

--- a/src/plugins/localization/en.ts
+++ b/src/plugins/localization/en.ts
@@ -132,6 +132,8 @@ export default {
       title: 'Word Replace',
       description: 'Add words or phrases to replace here',
       enabled: 'Enable replacing words or phrases',
+      match_whole_word: 'Match whole word only',
+      match_case: 'Match case',
       info: 'Use the + button to add a new replacement!',
       replacing: 'Replacing',
       replacement: 'Replacement',

--- a/src/plugins/localization/es.ts
+++ b/src/plugins/localization/es.ts
@@ -131,6 +131,8 @@ export default {
       title: 'Sustitución de palabras',
       description: 'Agregue palabras o frases para reemplazar aquí',
       enabled: 'Permitir reemplazar palabras o frases',
+      match_whole_word: 'Sólo palabras completas',
+      match_case: 'Coincidir mayúsculas/minúsculas',
       info: 'Utilice el botón + para agregar un nuevo reemplazo.',
       replacing: 'Reemplazando ',
       replacement: 'Reemplazo',

--- a/src/plugins/localization/ja.ts
+++ b/src/plugins/localization/ja.ts
@@ -132,6 +132,8 @@ export default {
       title: 'テキストリプレース',
       description: 'ここで置き換えるテキストを追加します',
       enabled: 'テキストリプレース',
+      match_whole_word: '単語単位',
+      match_case: '大文字/小文字を区別',
       info: '新しい置き換えを追加する場合は「＋」バタンを使用してください',
       replacing: 'リプレース',
       replacement: 'リプレースメント',

--- a/src/stores/speech.ts
+++ b/src/stores/speech.ts
@@ -109,7 +109,7 @@ export const useSpeechStore = defineStore('speech', {
       speech.speak(input)
     },
     async on_submit(log: any, index: number) {
-      if (!log.transcript.replace(/\s/g, '').length)
+      if (!log.transcript.trim()) // If the submitted input is only whitespace, do nothing. This may occur if the user only submitted whitespace.
         return
 
       const logStore = useLogStore()
@@ -124,6 +124,11 @@ export const useSpeechStore = defineStore('speech', {
 
       // word replace
       log.transcript = replace_words(log.transcript)
+      if (!log.transcript.trim()) { // If the processed input is only whitespace, do nothing. This may occur if the entire log transcript was replaced with whitespace.
+        logStore.loading_result = false
+        
+        return
+      }
 
       // scroll to bottom
       const loglist = document.getElementById('loglist')

--- a/src/stores/speech.ts
+++ b/src/stores/speech.ts
@@ -126,7 +126,7 @@ export const useSpeechStore = defineStore('speech', {
       log.transcript = replace_words(log.transcript)
       if (!log.transcript.trim()) { // If the processed input is only whitespace, do nothing. This may occur if the entire log transcript was replaced with whitespace.
         logStore.loading_result = false
-        
+
         return
       }
 

--- a/src/stores/word_replace.ts
+++ b/src/stores/word_replace.ts
@@ -22,9 +22,13 @@ export const useWordReplaceStore = defineStore('wordreplace', {
 
       // Replace words.
       // Keys are case-sensitive (e.g., "Hello" and "hello" are different replacement keys).
+      // Longer keys have higher priority. (E.g., "Hello world" → "apple", "Hello" → "banana". The transcript "Hello world" will become "apple" instead of "banana world".) Keys are sorted when Word Replace is unmounted.
       // Word boundaries prevent abnormal replacements (e.g, "script" → "HELLO" would cause "description" → "deHELLOion").
       // The shortest censored word is expected to have at least 2 asterisks.
-      const joined = Object.keys(this.word_replacements).map(key => this.escapeRegExp(key)).join("|")
+      const joined = Object.keys(this.word_replacements)
+        .map(key => this.escapeRegExp(key))
+        .join("|")
+
       const replace_re = new RegExp(`\\b(${joined})(?![\\w*]{2,})`, "g")
       
       return input.replace(replace_re, (matched) => {

--- a/src/stores/word_replace.ts
+++ b/src/stores/word_replace.ts
@@ -10,6 +10,7 @@ export const useWordReplaceStore = defineStore('wordreplace', {
     match_whole_word: false,
     match_case: false,
     word_replacements: {} as word_replacements,
+    word_replacements_lowercase: {} as word_replacements,
   }),
   getters: {
 
@@ -23,15 +24,38 @@ export const useWordReplaceStore = defineStore('wordreplace', {
         return input
 
       // Replace words.
-      // Longer keys have higher priority (e.g., with "Hello world" → "apple" and "Hello" → "banana", the transcript "Hello world" will become "apple".). Keys are sorted in the Word Replace component.
-      const joined = Object.keys(this.word_replacements)
-        .map(key => this.escapeRegExp(key))
-        .join("|")
+      // Longer keys have higher priority (e.g., "Hello world" → "apple", "Hello" → "banana". The transcript "Hello world" will become "apple"). Keys are sorted by the Word Replace component.
 
-      const replace_re = new RegExp(joined, "g")
-      
-      return input.replace(replace_re, (matched) => {
-        return this.word_replacements[matched.toLowerCase()]
+      // Interpret depending on the "Match case" option.
+      let inputInterpretation
+      let joinedKeys
+
+      if (!this.match_case) { // Option: Do not match case. Case-insensitive.
+        inputInterpretation = input.toLowerCase()
+        joinedKeys = Object.keys(this.word_replacements_lowercase)
+      }
+      else { // Option: Match case. Case-sensitive.
+        inputInterpretation = input
+        joinedKeys = Object.keys(this.word_replacements)
+      }
+
+      joinedKeys = joinedKeys.map(key => this.escapeRegExp(key)).join("|")
+
+      // Build pattern depending on options.
+      let pattern
+
+      if (!this.match_whole_word) // Option. Word/phrase match. Word boundaries prevent unexpected replacements (e.g, "script" → "HELLO" would undesirably cause "description" → "deHELLOion").
+        pattern = joinedKeys
+      else
+        pattern = "(?<![\\w*])(" + joinedKeys + ")(?![\\w*])"
+
+      const replace_re = new RegExp(pattern, "g")
+
+      return inputInterpretation.replace(replace_re, (matched) => {
+        if (!this.match_case)
+          return this.word_replacements_lowercase[matched.toLowerCase()]
+        else
+          return this.word_replacements[matched]
       })
     },
   },

--- a/src/stores/word_replace.ts
+++ b/src/stores/word_replace.ts
@@ -23,12 +23,12 @@ export const useWordReplaceStore = defineStore('wordreplace', {
       // Replace words.
       // Keys are case-sensitive (e.g., "Hello" and "hello" are different replacement keys).
       // Longer keys have higher priority. (E.g., "Hello world" → "apple", "Hello" → "banana". The transcript "Hello world" will become "apple" instead of "banana world".) Keys are sorted when Word Replace is unmounted.
-      // Word boundaries prevent unexpected replacements (e.g, "script" → "HELLO" would cause "description" → "deHELLOion").
+      // Users are responsible for defining their own word boundaries. This design choice has more support for various languages and speech styles.
       const joined = Object.keys(this.word_replacements)
         .map(key => this.escapeRegExp(key))
         .join("|")
 
-      const replace_re = new RegExp(`(?<![\\w*])(${joined})(?![\\w*])`, "g")
+      const replace_re = new RegExp(joined, "g")
       
       return input.replace(replace_re, (matched) => {
         return this.word_replacements[matched]

--- a/src/stores/word_replace.ts
+++ b/src/stores/word_replace.ts
@@ -13,14 +13,19 @@ export const useWordReplaceStore = defineStore('wordreplace', {
 
   },
   actions: {
+    escapeRegExp(input: string) {
+      return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // Escape regex metacharacters.
+    },
     replace_words(input: string): string {
       if (!this.enabled || !Object.keys(this.word_replacements).length)
         return input
 
       // Replace words.
       // Keys are case-sensitive (e.g., "Hello" and "hello" are different replacement keys).
-      // Word boundaries (\b) prevent abnormal replacements (e.g, "script" → "HELLO" would cause "description" → "deHELLOion").
-      const replace_re = new RegExp("\\b(" + Object.keys(this.word_replacements).join("|") + ")\\b", "g");
+      // Word boundaries prevent abnormal replacements (e.g, "script" → "HELLO" would cause "description" → "deHELLOion").
+      // The shortest censored word is expected to have at least 2 asterisks.
+      const joined = Object.keys(this.word_replacements).map(key => this.escapeRegExp(key)).join("|")
+      const replace_re = new RegExp(`\\b(${joined})(?![\\w*]{2,})`, "g")
       
       return input.replace(replace_re, (matched) => {
         return this.word_replacements[matched]

--- a/src/stores/word_replace.ts
+++ b/src/stores/word_replace.ts
@@ -23,13 +23,12 @@ export const useWordReplaceStore = defineStore('wordreplace', {
       // Replace words.
       // Keys are case-sensitive (e.g., "Hello" and "hello" are different replacement keys).
       // Longer keys have higher priority. (E.g., "Hello world" → "apple", "Hello" → "banana". The transcript "Hello world" will become "apple" instead of "banana world".) Keys are sorted when Word Replace is unmounted.
-      // Word boundaries prevent abnormal replacements (e.g, "script" → "HELLO" would cause "description" → "deHELLOion").
-      // The shortest censored word is expected to have at least 2 asterisks.
+      // Word boundaries prevent unexpected replacements (e.g, "script" → "HELLO" would cause "description" → "deHELLOion").
       const joined = Object.keys(this.word_replacements)
         .map(key => this.escapeRegExp(key))
         .join("|")
 
-      const replace_re = new RegExp(`\\b(${joined})(?![\\w*]{2,})`, "g")
+      const replace_re = new RegExp(`(?<![\\w*])(${joined})(?![\\w*])`, "g")
       
       return input.replace(replace_re, (matched) => {
         return this.word_replacements[matched]

--- a/src/stores/word_replace.ts
+++ b/src/stores/word_replace.ts
@@ -16,9 +16,14 @@ export const useWordReplaceStore = defineStore('wordreplace', {
     replace_words(input: string): string {
       if (!this.enabled || !Object.keys(this.word_replacements).length)
         return input
-      const replace_re = new RegExp(Object.keys(this.word_replacements).join('|'), 'gi')
+
+      // Replace words.
+      // Keys are case-sensitive (e.g., "Hello" and "hello" are different replacement keys).
+      // Word boundaries (\b) prevent abnormal replacements (e.g, "script" → "HELLO" would cause "description" → "deHELLOion").
+      const replace_re = new RegExp("\\b(" + Object.keys(this.word_replacements).join("|") + ")\\b", "g");
+      
       return input.replace(replace_re, (matched) => {
-        return this.word_replacements[matched.toLowerCase()]
+        return this.word_replacements[matched]
       })
     },
   },

--- a/src/stores/word_replace.ts
+++ b/src/stores/word_replace.ts
@@ -7,6 +7,8 @@ interface word_replacements {
 export const useWordReplaceStore = defineStore('wordreplace', {
   state: () => ({
     enabled: true,
+    match_whole_word: false,
+    match_case: false,
     word_replacements: {} as word_replacements,
   }),
   getters: {

--- a/src/stores/word_replace.ts
+++ b/src/stores/word_replace.ts
@@ -21,9 +21,7 @@ export const useWordReplaceStore = defineStore('wordreplace', {
         return input
 
       // Replace words.
-      // Keys are case-sensitive (e.g., "Hello" and "hello" are different replacement keys).
-      // Longer keys have higher priority. (E.g., "Hello world" → "apple", "Hello" → "banana". The transcript "Hello world" will become "apple" instead of "banana world".) Keys are sorted when Word Replace is unmounted.
-      // Users are responsible for defining their own word boundaries. This design choice has more support for various languages and speech styles.
+      // Longer keys have higher priority (e.g., with "Hello world" → "apple" and "Hello" → "banana", the transcript "Hello world" will become "apple".). Keys are sorted in the Word Replace component.
       const joined = Object.keys(this.word_replacements)
         .map(key => this.escapeRegExp(key))
         .join("|")
@@ -31,7 +29,7 @@ export const useWordReplaceStore = defineStore('wordreplace', {
       const replace_re = new RegExp(joined, "g")
       
       return input.replace(replace_re, (matched) => {
-        return this.word_replacements[matched]
+        return this.word_replacements[matched.toLowerCase()]
       })
     },
   },

--- a/src/stores/word_replace.ts
+++ b/src/stores/word_replace.ts
@@ -39,7 +39,7 @@ export const useWordReplaceStore = defineStore('wordreplace', {
         joinedKeys = Object.keys(this.word_replacements)
       }
 
-      joinedKeys = joinedKeys.map(key => this.escapeRegExp(key)).join("|")
+      joinedKeys = joinedKeys.map(key => this.escapeRegExp(key)).join('|')
 
       // Build pattern depending on options.
       let pattern
@@ -47,9 +47,9 @@ export const useWordReplaceStore = defineStore('wordreplace', {
       if (!this.match_whole_word) // Option. Word/phrase match. Word boundaries prevent unexpected replacements (e.g, "script" → "HELLO" would undesirably cause "description" → "deHELLOion").
         pattern = joinedKeys
       else
-        pattern = "(?<![\\w*])(" + joinedKeys + ")(?![\\w*])"
+        pattern = `(?<![\\w*])(${joinedKeys})(?![\\w*])`
 
-      const replace_re = new RegExp(pattern, "g")
+      const replace_re = new RegExp(pattern, 'g')
 
       return inputInterpretation.replace(replace_re, (matched) => {
         if (!this.match_case)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description <!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This is a collection of changes to the Word Replace system.

# Case Sensitivity
Word Replace will become dependent on capitalization.

For example, `Apple` and `apple` will be treated as two different entries.

This is semantically important.

For example, the user may only want to transform the capitalization of a word.
- The current system is case-insensitive and forcibly writes replacement keys in lowercase, such as `pizza`➔`pizza`. This implicitly means "any capitalization of `pizza`, `Pizza`, `pIzza`, `piZza`, and etc. that will be replaced by a user-specified replacement value." This example shows how the change in capitalization is not visually communicated.
- With case-sensitivity, we can have a visually meaningful display of the change (e.g., `Pizza`➔`pizza`). This visually communicates what is being changed.

This enables users to specifically target common nouns and proper nouns.

However, case-sensitivity is more explicit, so it may be more difficult to use. When using speech-to-text, the user will have to declare their replacement keys according to the output of the Web Speech API.

# Sanitization
When text is being processed for replacement, regex metacharacters in replacement keys will be automatically escaped to prevent the accidental injection of regular expressions.

The user's entries will not be modified and will remain as the user has declared them.

This fixes a crash that required a refresh of the running instance.

Additionally, users can now replace words/phrases that contain special characters (e.g., words with many asterisks).

# Replacement Prioritization
Longer replacement keys will have higher priority than shorter replacement keys.

For example, we may have 2 entries.
`Hello world`➔`apple`
`Hello`➔`banana`

`Hello world` is the longer key; therefore, it has higher priority.
The transcript `Hello world` will become `apple` instead of `banana world`.

# (Other)
This has only been tested for the English language.
I haven't fully determined whether it's functional and stable with other languages.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other
