### PR TITLE
update osc params

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -250,7 +250,7 @@ export default {
 
                   window.ipcRenderer.send('send-param-event', { ip: custom_param.ip, port: custom_param.port, route: custom_param.route, value: newValue })
 
-                  if (custom_param.behavior === "Pulse") {
+                  if (custom_param.activation_signal === "Pulse") {
                     setTimeout(() => {
 
                       switch (assign.type) {
@@ -266,7 +266,7 @@ export default {
                       }
 
                       window.ipcRenderer.send('send-param-event', { ip: custom_param.ip, port: custom_param.port, route: custom_param.route, value: newValue })
-                    }, 200)
+                    }, custom_param.pulse_delay)
                   }
                 }
               })

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -226,7 +226,27 @@ export default {
                 const matchesAssign = reAssign.exec(input)
                 if (matchesAssign) {
                   this.show_snackbar('secondary', `<code>${custom_param.route} = ${assign.set}</code>`)
-                  window.ipcRenderer.send('send-param-event', { ip: custom_param.ip, port: custom_param.port, route: custom_param.route, value: assign.set })
+
+                  let newValue
+
+                  switch (assign.type) {
+                    case 'int':
+                    case 'float':
+                      newValue = Number(assign.set)
+                      
+                      break
+                    case 'bool':
+                      if (assign.set === "true")
+                        newValue = true
+                      else if (assign.set === "false")
+                        newValue = false
+                      else
+                        newValue = Boolean(assign.set)
+
+                      break
+                  }
+
+                  window.ipcRenderer.send('send-param-event', { ip: custom_param.ip, port: custom_param.port, route: custom_param.route, value: newValue })
                 }
               })
             }

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -229,7 +229,7 @@ export default {
                 if (matchesAssign) {
                   this.show_snackbar('secondary', `<code>${custom_param.route} = ${assign.set}</code>`)
 
-                  let newValue
+                  let newValue : number | boolean | null = null
 
                   switch (assign.type) {
                     case 'int':
@@ -249,6 +249,25 @@ export default {
                   }
 
                   window.ipcRenderer.send('send-param-event', { ip: custom_param.ip, port: custom_param.port, route: custom_param.route, value: newValue })
+
+                  if (custom_param.behavior === "Pulse") {
+                    setTimeout(() => {
+
+                      switch (assign.type) {
+                        case 'int':
+                        case 'float':
+                          newValue = 0
+
+                          break
+                        case 'bool':
+                          newValue = false
+
+                          break
+                      }
+
+                      window.ipcRenderer.send('send-param-event', { ip: custom_param.ip, port: custom_param.port, route: custom_param.route, value: newValue })
+                    }, 200)
+                  }
                 }
               })
             }

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -250,7 +250,7 @@ export default {
 
                   window.ipcRenderer.send('send-param-event', { ip: custom_param.ip, port: custom_param.port, route: custom_param.route, value: newValue })
 
-                  if (custom_param.activation_signal === "Pulse") {
+                  if (custom_param.activation_signal === "pulse") {
                     // The value should reset after some time.
                     setTimeout(() => {
 

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -251,16 +251,17 @@ export default {
                   window.ipcRenderer.send('send-param-event', { ip: custom_param.ip, port: custom_param.port, route: custom_param.route, value: newValue })
 
                   if (custom_param.activation_signal === "Pulse") {
+                    // The value should reset after some time.
                     setTimeout(() => {
 
                       switch (assign.type) {
                         case 'int':
                         case 'float':
-                          newValue = 0
+                          newValue = (Number(newValue) > 0) ? 0 : 1
 
                           break
                         case 'bool':
-                          newValue = false
+                          newValue = !newValue
 
                           break
                       }

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -227,47 +227,53 @@ export default {
                 const reAssign = new RegExp(assign_check, 'ig')
                 const matchesAssign = reAssign.exec(input)
                 if (matchesAssign) {
-                  this.show_snackbar('secondary', `<code>${custom_param.route} = ${assign.set}</code>`)
+                  this.show_snackbar('secondary', `<code>${custom_param.route} = ${assign.set1}</code>`)
 
                   let newValue : number | boolean | null = null
 
                   switch (assign.type) {
                     case 'int':
                     case 'float':
-                      newValue = Number(assign.set)
+                      newValue = Number(assign.set1)
                       
                       break
                     case 'bool':
-                      if (assign.set === "true")
+                      if (assign.set1 === "true")
                         newValue = true
-                      else if (assign.set === "false")
+                      else if (assign.set1 === "false")
                         newValue = false
                       else
-                        newValue = Boolean(assign.set)
+                        newValue = Boolean(assign.set1)
 
                       break
                   }
 
                   window.ipcRenderer.send('send-param-event', { ip: custom_param.ip, port: custom_param.port, route: custom_param.route, value: newValue })
 
-                  if (custom_param.activation_signal === "pulse") {
+                  if (assign.activation === "pulse") {
                     // The value should reset after some time.
                     setTimeout(() => {
+                      this.show_snackbar('secondary', `<code>${custom_param.route} = ${assign.set2}</code>`)
 
                       switch (assign.type) {
                         case 'int':
                         case 'float':
-                          newValue = (Number(newValue) > 0) ? 0 : 1
+                          newValue = Number(assign.set2)
 
                           break
                         case 'bool':
-                          newValue = !newValue
+                          if (assign.set2 === "true")
+                            newValue = true
+                          else if (assign.set2 === "false")
+                            newValue = false
+                          else
+                            newValue = Boolean(assign.set2)
 
                           break
                       }
 
                       window.ipcRenderer.send('send-param-event', { ip: custom_param.ip, port: custom_param.port, route: custom_param.route, value: newValue })
-                    }, custom_param.pulse_delay)
+                    }, assign.pulse_duration)
                   }
                 }
               })

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -209,8 +209,8 @@ export default {
         // use https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/search
         // to see which assign is the closest to the keyword found
         // unless switch to nlp first.....
-        if (this.oscStore.osc_params.length) {
-          this.oscStore.osc_params.forEach((custom_param) => {
+        if (this.oscStore.osc_profiles[this.oscStore.current_profile].length) {
+          this.oscStore.osc_profiles[this.oscStore.current_profile].forEach((custom_param) => {
             let matchesKey: RegExpExecArray | null = null
 
             custom_param.keywords.forEach((keyword) => {

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -214,7 +214,8 @@ export default {
             let matchesKey: RegExpExecArray | null = null
 
             custom_param.keywords.forEach((keyword) => {
-              if (matchesKey) return
+              if (matchesKey)
+                return
 
               const key_check = `(^|\\s)(${keyword.text})($|[^a-zA-Z\\d])`
               const reKey = new RegExp(key_check, 'ig')
@@ -229,18 +230,18 @@ export default {
                 if (matchesAssign) {
                   this.show_snackbar('secondary', `<code>${custom_param.route} = ${assign.set1}</code>`)
 
-                  let newValue : number | boolean | null = null
+                  let newValue: number | boolean | null = null
 
                   switch (assign.type) {
                     case 'int':
                     case 'float':
                       newValue = Number(assign.set1)
-                      
+
                       break
                     case 'bool':
-                      if (assign.set1 === "true")
+                      if (assign.set1 === 'true')
                         newValue = true
-                      else if (assign.set1 === "false")
+                      else if (assign.set1 === 'false')
                         newValue = false
                       else
                         newValue = Boolean(assign.set1)
@@ -250,7 +251,7 @@ export default {
 
                   window.ipcRenderer.send('send-param-event', { ip: custom_param.ip, port: custom_param.port, route: custom_param.route, value: newValue })
 
-                  if (assign.activation === "pulse") {
+                  if (assign.activation === 'pulse') {
                     // The value should reset after some time.
                     setTimeout(() => {
                       this.show_snackbar('secondary', `<code>${custom_param.route} = ${assign.set2}</code>`)
@@ -262,9 +263,9 @@ export default {
 
                           break
                         case 'bool':
-                          if (assign.set2 === "true")
+                          if (assign.set2 === 'true')
                             newValue = true
-                          else if (assign.set2 === "false")
+                          else if (assign.set2 === 'false')
                             newValue = false
                           else
                             newValue = Boolean(assign.set2)

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -211,9 +211,11 @@ export default {
         // unless switch to nlp first.....
         if (this.oscStore.osc_params.length) {
           this.oscStore.osc_params.forEach((custom_param) => {
-            let matchesKey = null
+            let matchesKey: RegExpExecArray | null = null
 
             custom_param.keywords.forEach((keyword) => {
+              if (matchesKey) return
+
               const key_check = `(^|\\s)(${keyword.text})($|[^a-zA-Z\\d])`
               const reKey = new RegExp(key_check, 'ig')
               matchesKey = reKey.exec(input)

--- a/src/components/settings/General.vue
+++ b/src/components/settings/General.vue
@@ -81,6 +81,7 @@ import { useSpeechStore } from '@/stores/speech'
 import { useConnectionStore } from '@/stores/connections'
 import { useLogStore } from '@/stores/logs'
 import { useTranslationStore } from '@/stores/translation'
+import { useOSCStore } from '@/stores/osc'
 
 export default {
   name: 'SettingsGeneral',
@@ -92,6 +93,7 @@ export default {
     const connectionStore = useConnectionStore()
     const logStore = useLogStore()
     const translationStore = useTranslationStore()
+    const oscStore = useOSCStore()
 
     return {
       appearanceStore,
@@ -101,6 +103,7 @@ export default {
       connectionStore,
       logStore,
       translationStore,
+      oscStore,
     }
   },
   data: () => ({
@@ -146,6 +149,8 @@ export default {
         this.connectionStore.$reset()
       if (this.translationStore)
         this.translationStore.$reset()
+      if (this.oscStore)
+        this.oscStore.$reset()
       this.reset_dialog = false
       this.snackbar_text = this.$t('settings.general.reset.snackbar.title')
       this.snackbar = true

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -109,7 +109,7 @@
     </v-card-text>
     <!-- Profile Dialog -->
     <v-row justify="center">
-      <v-dialog v-model="profile_dialog" width="50vw" persistent>
+      <v-dialog v-model="profile_dialog" width="50vw">
         <v-card>
           <v-card-title>Add new profile</v-card-title>
           <v-card-text>
@@ -134,7 +134,7 @@
     </v-row>
     <!-- Profile Delete Dialog -->
     <v-row justify="center">
-      <v-dialog v-model="profile_delete_dialog" width="50vw" persistent>
+      <v-dialog v-model="profile_delete_dialog" width="50vw">
         <v-card>
           <v-card-title>Delete profile</v-card-title>
           <v-card-text>{{ `Are you sure that you want to delete "${profile_delete_target}"?` }}</v-card-text>

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -7,7 +7,7 @@
       </v-chip>
     </template>
     <template v-slot:subtitle>
-      <span>Add custom param triggers here</span>
+      <span v-html="$t('settings.osc.params.description')"></span>
     </template>
     <v-divider />
     <v-card-text>
@@ -15,7 +15,7 @@
         <v-col :cols="10" class="d-flex align-center">
           <v-select
             v-model="oscStore.current_profile"
-            label="Select a profile"
+            :label="$t('settings.osc.params.menu.profile')"
             :items="Object.keys(oscStore.osc_profiles)"
             variant="outlined"
             :menu-props="{ closeOnContentClick: true }"
@@ -46,10 +46,10 @@
             {{ param.route }}
             <v-spacer />
             <v-btn class="ml-4" flat variant="text" size="small" color="primary" append-icon="mdi-pencil" @click="openEditDialog(i)">
-              Edit
+              {{ $t('settings.osc.params.param.button.edit') }}
             </v-btn>
             <v-btn class="ml-4" flat variant="text" size="small" color="error" append-icon="mdi-delete" @click="delete_param(i)">
-              Delete
+              {{ $t('settings.osc.params.param.button.delete') }}
             </v-btn>
           </v-card-title>
           <v-divider />
@@ -59,14 +59,14 @@
                                 <v-text-field v-model="param.name" label="Name" hide-details></v-text-field>
                             </v-col> -->
               <v-col :cols="12" :md="6">
-                <v-text-field v-model="param.ip" label="Default OSC IP" variant="outlined" hide-details readonly />
+                <v-text-field v-model="param.ip" :label="$t('settings.osc.general.osc_ip')" variant="outlined" hide-details readonly />
               </v-col>
               <v-col>
-                <v-text-field v-model="param.port" label="Default OSC Port" variant="outlined" hide-details readonly />
+                <v-text-field v-model="param.port" :label="$t('settings.osc.general.osc_port')" variant="outlined" hide-details readonly />
               </v-col>
 
               <v-col :cols="12">
-                <strong>Trigger phrases:</strong>
+                <strong v-html="$t('settings.osc.params.param.trigger_phrases')"></strong>
               </v-col>
               <v-col :cols="12">
                 <v-chip v-for="(keyword, i) in param.keywords" v-model="keyword.enabled" class="mx-1 mb-2" label color="secondary" size="small">
@@ -74,7 +74,7 @@
                 </v-chip>
               </v-col>
               <v-col :cols="12">
-                <strong>Assign phrases:</strong>
+                <strong v-html="$t('settings.osc.params.param.assign_phrases')"></strong>
                 <v-list density="compact">
                   <v-list-item
                     v-for="(assign, i) in param.assigns"
@@ -86,11 +86,11 @@
                 </v-list>
               </v-col>
               <v-col :cols="12">
-                <strong>Behavior:</strong>
+                <strong v-html="$t('settings.osc.params.param.behavior')"></strong>
                 <v-list density="compact">
                   <v-list-item
                     :value="param"
-                    :title="`${param.activation_signal}${param.activation_signal === 'Pulse' ? ` (${param.pulse_delay}ms)` : ''}`"
+                    :title="`${$t('settings.osc.params.param.activation_signal_options.' + param.activation_signal)}${param.activation_signal === 'pulse' ? ` (${param.pulse_delay}ms)` : ''}`"
                     class="display-only"
                   />
                 </v-list>
@@ -99,9 +99,7 @@
           </v-card-text>
         </v-card>
       </v-card>
-      <p v-else>
-        Use the + button to add a new custom param trigger!
-      </p>
+      <p v-else v-html="$t('settings.osc.params.empty')"></p>
       <v-card class="mt-2" color="transparent" flat>
         <v-card-actions>
           <v-btn color="primary" variant="outlined" size="small" icon="mdi-plus" @click="openAddParamDialog" />
@@ -112,11 +110,11 @@
     <v-row justify="center">
       <v-dialog v-model="profile_dialog" width="50vw">
         <v-card>
-          <v-card-title>Add new profile</v-card-title>
+          <v-card-title>{{ $t('settings.osc.params.menu.profile_add') }}</v-card-title>
           <v-card-text>
             <v-row>
               <v-col :cols="12">
-                <v-text-field v-model="new_profile_name" label="Profile name" hide-details />
+                <v-text-field v-model="new_profile_name" :label="$t('settings.osc.params.menu.profile_add_label')" hide-details />
               </v-col>
             </v-row>
           </v-card-text>
@@ -124,10 +122,10 @@
           <v-card-actions>
             <v-spacer />
             <v-btn @click="profile_dialog = false">
-              cancel
+              {{ $t('settings.osc.params.button.cancel') }}
             </v-btn>
             <v-btn color="primary" @click="confirmNewProfile">
-              confirm
+              {{ $t('settings.osc.params.button.add') }}
             </v-btn>
           </v-card-actions>
         </v-card>
@@ -137,15 +135,15 @@
     <v-row justify="center">
       <v-dialog v-model="profile_delete_dialog" width="50vw">
         <v-card>
-          <v-card-title>Delete profile</v-card-title>
-          <v-card-text>{{ `Are you sure that you want to delete "${profile_delete_target}"?` }}</v-card-text>
+          <v-card-title>{{ $t('settings.osc.params.menu.profile_delete') }}</v-card-title>
+          <v-card-text>{{ $t('settings.osc.params.menu.profile_delete_text') }}</v-card-text>
           <v-card-actions>
             <v-spacer />
             <v-btn @click="profile_delete_dialog = false">
-              cancel
+              {{ $t('settings.osc.params.button.cancel') }}
             </v-btn>
             <v-btn color="primary" @click="delete_profile_final()">
-              confirm
+              {{ $t('settings.osc.params.button.delete') }}
             </v-btn>
           </v-card-actions>
         </v-card>
@@ -155,14 +153,15 @@
     <v-row justify="center">
       <v-dialog v-model="param_dialog" width="50vw" persistent>
         <v-card>
-          <v-card-title>{{ `${!editing ? 'Add' : 'Edit'} custom param trigger` }}</v-card-title>
+          <v-card-title v-if="!editing">{{ $t('settings.osc.params.param.dialog_title.adding') }}</v-card-title>
+          <v-card-title v-else>{{ $t('settings.osc.params.param.dialog_title.editing') }}</v-card-title>
           <v-card-text>
             <v-row>
               <!-- <v-col :cols="12">
                                 <v-text-field v-model="new_param.name" label="Name" hide-details></v-text-field>
                             </v-col> -->
               <v-col :cols="12">
-                <v-text-field v-model="new_param.route" label="Param route" hide-details />
+                <v-text-field v-model="new_param.route" :label="$t('settings.osc.params.param.address')" hide-details />
               </v-col>
               <v-col :cols="12" :md="6">
                 <v-text-field v-model="new_param.ip" label="OSC IP" hide-details />
@@ -179,18 +178,27 @@
             <v-row>
               <!-- <v-col :cols="12"><strong>Trigger phrases</strong></v-col> -->
               <v-col>
-                <strong>Trigger phrases:</strong>
+                <strong v-html="$t('settings.osc.params.param.trigger_phrases')"></strong>
                 <v-chip v-if="!new_param.keywords.length" variant="text">
-                  none :c
+                  {{ $t('settings.osc.params.param.empty') }}
                 </v-chip>
-                <v-chip v-for="(keyword, i) in new_param.keywords" v-else v-model="keyword.enabled" class="mx-1 mb-2" label color="secondary" size="small" closable @click:close="remove_trigger(i)">
+                <v-chip
+                  v-else v-model="keyword.enabled"
+                  v-for="(keyword, i) in new_param.keywords"
+                  class="mx-1 mb-2"
+                  label
+                  color="secondary"
+                  size="small"
+                  closable
+                  @click:close="remove_trigger(i)"
+                >
                   {{ keyword.text }}
                 </v-chip>
               </v-col>
               <v-col :cols="12">
                 <v-text-field
                   v-model="trigger_phrase"
-                  label="Add trigger word/phrase"
+                  :label="$t('settings.osc.params.param.trigger_phrases_add')"
                   hide-details
                   append-icon="mdi-plus"
                   @click:append="add_trigger"
@@ -205,9 +213,9 @@
           <v-card-text class="mt-2">
             <v-row>
               <v-col :cols="12">
-                <strong>Assign phrases:</strong>
+                <strong v-html="$t('settings.osc.params.param.assign_phrases')"></strong>
                 <v-chip v-if="!new_param.assigns.length" variant="text">
-                  none :c
+                  {{ $t('settings.osc.params.param.empty') }}
                 </v-chip>
                 <v-list density="compact">
                   <v-list-item
@@ -221,16 +229,35 @@
                 </v-list>
               </v-col>
               <v-col :cols="12" :lg="4">
-                <v-select v-model="new_assign.type" :items="var_types" hide-details label="Value type" @update:modelValue="validate_assign_value_field" />
+                <v-select
+                  v-model="new_assign.type"
+                  :items="var_types"
+                  hide-details
+                  :label="$t('settings.osc.params.param.assign_phrases_type')"
+                  @update:modelValue="validate_assign_value_field"
+                />
               </v-col>
               <v-col :cols="12" :lg="8">
-                <v-text-field v-if="new_assign.type !== 'bool'" v-model="new_assign.set" hide-details label="Value" type="number" @input="validate_assign_value_field" />
-                <v-select v-else v-model="new_assign.set" :items="['true', 'false'] as string[]" hide-details label="Value" />
+                <v-text-field
+                  v-if="new_assign.type !== 'bool'"
+                  v-model="new_assign.set"
+                  hide-details
+                  :label="$t('settings.osc.params.param.assign_phrases_value')"
+                  type="number"
+                  @input="validate_assign_value_field"
+                />
+                <v-select
+                  v-else
+                  v-model="new_assign.set"
+                  :items="['true', 'false']"
+                  hide-details
+                  :label="$t('settings.osc.params.param.assign_phrases_value')"
+                />
               </v-col>
               <v-col :cols="12">
                 <v-text-field
                   v-model="new_assign.keyword"
-                  label="Add assign word/phrase (ex: on)"
+                  :label="$t('settings.osc.params.param.assign_phrases_add')"
                   hide-details
                   append-icon="mdi-plus"
                   @click:append="add_assign"
@@ -245,13 +272,30 @@
           <v-card-text class="mt-2">
             <v-row>
               <v-col :cols="12">
-                <strong>Behavior:</strong>
+                <strong v-html="$t('settings.osc.params.param.behavior')"></strong>
               </v-col>
               <v-col :cols="6">
-                <v-select v-model="new_param.activation_signal" :items="['Constant', 'Pulse'] as string[]" hide-details label="Activation signal" />
+                <v-select
+                  v-model="new_param.activation_signal"
+                  :items="[
+                    { name: $t('settings.osc.params.param.activation_signal_options.constant'), value: 'constant' },
+                    { name: $t('settings.osc.params.param.activation_signal_options.pulse'), value: 'pulse' }
+                  ]"
+                  item-title="name"
+                  item-value="value"
+                  hide-details
+                  :label="$t('settings.osc.params.param.activation_signal')"
+                />
               </v-col>
               <v-col :cols="6">
-                <v-text-field v-if="new_param.activation_signal === 'Pulse'" v-model="new_param.pulse_delay" hide-details label="Pulse duration (milliseconds)" type="number" @input="new_param.pulse_delay = Math.round(new_param.pulse_delay)" />
+                <v-text-field
+                  v-if="new_param.activation_signal === 'pulse'"
+                  v-model="new_param.pulse_delay"
+                  hide-details
+                  :label="$t('settings.osc.params.param.activation_signal_options.pulse_duration')"
+                  type="number"
+                  @input="new_param.pulse_delay = Math.round(new_param.pulse_delay)"
+                />
               </v-col>
             </v-row>
           </v-card-text>
@@ -267,10 +311,10 @@
           <v-card-actions>
             <v-spacer />
             <v-btn @click="closeDialog">
-              cancel
+              {{ $t('settings.osc.params.button.cancel') }}
             </v-btn>
             <v-btn color="primary" @click="confirm_param">
-              confirm
+              {{ $t('settings.osc.params.button.confirm') }}
             </v-btn>
           </v-card-actions>
         </v-card>
@@ -349,9 +393,9 @@ export default {
       keywords: [] as Keyword[], // [{enabled: boolean, text: string}?],
       assigns: [] as Assign[], // [{keyword: string, type: string, set: string}?]
 
-      // "Constant" (Default): set the parameter to this value.
-      // "Pulse": set the parameter to this value, then reset it (0, 0.0, false) after some time.
-      activation_signal: 'Constant',
+      // "constant" (Default): set the parameter to this value.
+      // "pulse": set the parameter to this value, then reset it (0, 0.0, false) after some time.
+      activation_signal: 'constant',
       pulse_delay: 0,
     },
   }),
@@ -385,7 +429,7 @@ export default {
         route: '/avatar/parameters/',
         keywords: [],
         assigns: [],
-        activation_signal: 'Constant',
+        activation_signal: 'constant',
         pulse_delay: 1000,
       }
 

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -9,14 +9,17 @@
     <template v-slot:subtitle>
       <span v-html="$t('settings.osc.params.description')"></span>
     </template>
+
     <v-divider />
+
     <v-card-text>
+      <!-- Profiles -->
       <v-row>
         <v-col :cols="10" class="d-flex align-center">
           <v-select
             v-model="oscStore.current_profile"
             :label="$t('settings.osc.params.profile.label')"
-            :items="sorted_profiles"
+            :items="sortedProfiles"
             variant="outlined"
             :menu-props="{ closeOnContentClick: true }"
           >
@@ -27,12 +30,22 @@
                     {{ item.title }}
                   </v-list-item-title>
                   <v-list-item-action>
-                    <v-btn icon variant="plain" density="comfortable" @click.stop="openRenameProfileDialog(item.title)">
+                    <v-btn
+                      icon
+                      variant="plain"
+                      density="comfortable"
+                      @click.stop="openEditProfileDialog(item.title)"
+                    >
                       <v-icon v-if="item.title !== 'Default'">mdi-pencil-outline</v-icon>
                     </v-btn>
                   </v-list-item-action>
                   <v-list-item-action class="ml-2">
-                    <v-btn icon variant="plain" density="comfortable" @click.stop="delete_profile(item.title)">
+                    <v-btn
+                      icon
+                      variant="plain"
+                      density="comfortable"
+                      @click.stop="openDeleteProfileDialog(item.title)"
+                    >
                       <v-icon v-if="item.title !== 'Default'">mdi-close</v-icon>
                     </v-btn>
                   </v-list-item-action>
@@ -42,18 +55,45 @@
           </v-select>
         </v-col>
         <v-card-actions class="pa-3" style="height: 80px">
-          <v-btn color="primary" variant="outlined" size="small" icon="mdi-plus" @click="openAddProfileDialog" />
+          <v-btn
+            color="primary"
+            variant="outlined"
+            size="small"
+            icon="mdi-plus"
+            @click="openAddProfileDialog"
+          />
         </v-card-actions>
       </v-row>
-      <v-card v-if="Object.keys(oscStore.osc_profiles[oscStore.current_profile]).length > 0" v-for="(param, i) in oscStore.osc_profiles[oscStore.current_profile]" class="mb-4">
+
+      <!-- Parameter Triggers -->
+      <v-card
+        v-if="Object.keys(oscStore.osc_profiles[oscStore.current_profile]).length > 0"
+        v-for="(param, i) in oscStore.osc_profiles[oscStore.current_profile]"
+        class="mb-4"
+      >
         <v-card color="rgba(0, 0, 0, 0)">
           <v-card-title class="d-flex align-center">
             {{ param.route }}
             <v-spacer />
-            <v-btn class="ml-4" flat variant="text" size="small" color="primary" append-icon="mdi-pencil" @click="openEditParamDialog(i)">
+            <v-btn
+              class="ml-4"
+              flat
+              variant="text"
+              size="small"
+              color="primary"
+              append-icon="mdi-pencil"
+              @click="openEditParamDialog(i)"
+            >
               {{ $t('settings.osc.params.param.button.edit') }}
             </v-btn>
-            <v-btn class="ml-4" flat variant="text" size="small" color="error" append-icon="mdi-delete" @click="delete_param(i)">
+            <v-btn
+              class="ml-4"
+              flat variant="text"
+              size="small"
+              color="error"
+              append-icon="mdi-delete"
+              @click="deleteParam(i)"
+            >
               {{ $t('settings.osc.params.param.button.delete') }}
             </v-btn>
           </v-card-title>
@@ -61,20 +101,38 @@
           <v-card-text>
             <v-row>
               <!-- <v-col :cols="12">
-                                <v-text-field v-model="param.name" label="Name" hide-details></v-text-field>
-                            </v-col> -->
+                <v-text-field v-model="param.name" label="Name" hide-details></v-text-field>
+              </v-col> -->
               <v-col :cols="12" :md="6">
-                <v-text-field v-model="param.ip" :label="$t('settings.osc.general.osc_ip')" variant="outlined" hide-details readonly />
+                <v-text-field
+                  v-model="param.ip"
+                  :label="$t('settings.osc.general.osc_ip')"
+                  variant="outlined"
+                  hide-details readonly
+                />
               </v-col>
               <v-col>
-                <v-text-field v-model="param.port" :label="$t('settings.osc.general.osc_port')" variant="outlined" hide-details readonly />
+                <v-text-field
+                  v-model="param.port"
+                  :label="$t('settings.osc.general.osc_port')"
+                  variant="outlined"
+                  hide-details
+                  readonly
+                />
               </v-col>
 
               <v-col :cols="12">
                 <strong v-html="$t('settings.osc.params.param.trigger_phrases')"></strong>
               </v-col>
               <v-col :cols="12">
-                <v-chip v-for="(keyword, i) in param.keywords" v-model="keyword.enabled" class="mx-1 mb-2" label color="secondary" size="small">
+                <v-chip
+                  v-for="(keyword, i) in param.keywords"
+                  v-model="keyword.enabled"
+                  class="mx-1 mb-2"
+                  label
+                  color="secondary"
+                  size="small"
+                >
                   {{ keyword.text }}
                 </v-chip>
               </v-col>
@@ -107,39 +165,75 @@
       <p v-else v-html="$t('settings.osc.params.empty')"></p>
       <v-card class="mt-2" color="transparent" flat>
         <v-card-actions>
-          <v-btn color="primary" variant="outlined" size="small" icon="mdi-plus" @click="openAddParamDialog" />
+          <v-btn
+            color="primary"
+            variant="outlined"
+            size="small"
+            icon="mdi-plus"
+            @click="openAddParamDialog"
+          />
         </v-card-actions>
       </v-card>
     </v-card-text>
-    <!-- Profile Dialog -->
+
+    <!-- Profile Add Dialog -->
     <v-row justify="center">
-      <v-dialog v-model="profile_dialog" width="50vw">
-        <v-card v-click-outside="closeProfileDialog">
-          <v-card-title v-if="!profile_editing">{{ $t('settings.osc.params.profile.dialog.title.add') }}</v-card-title>
-          <v-card-title v-else>{{ $t('settings.osc.params.profile.dialog.title.edit') }}</v-card-title>
+      <v-dialog v-model="profile_add_dialog" width="50vw">
+        <v-card v-click-outside="closeAddProfileDialog">
+          <v-card-title>{{ $t('settings.osc.params.profile.dialog.title.add') }}</v-card-title>
           <v-card-text>
             <v-row>
               <v-col :cols="12">
-                <v-text-field v-model="new_profile_name" :label="$t('settings.osc.params.profile.dialog.field_label')" hide-details />
+                <v-text-field
+                  v-model="new_profile_name"
+                  :label="$t('settings.osc.params.profile.dialog.field_label')"
+                  hide-details
+                />
               </v-col>
             </v-row>
           </v-card-text>
-
           <v-card-actions>
             <v-spacer />
-            <v-btn @click="closeProfileDialog">
+            <v-btn @click="closeAddProfileDialog">
               {{ $t('settings.osc.params.button.cancel') }}
             </v-btn>
-            <v-btn v-if="!profile_editing" color="primary" @click="confirmNewProfile">
+            <v-btn color="primary" @click="confirmAddProfileDialog">
               {{ $t('settings.osc.params.button.add') }}
             </v-btn>
-            <v-btn v-else color="primary" @click="confirmNewProfile">
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </v-row>
+
+    <!-- Profile Edit Dialog -->
+    <v-row justify="center">
+      <v-dialog v-model="profile_edit_dialog" width="50vw">
+        <v-card v-click-outside="confirmEditProfileDialog">
+          <v-card-title>{{ $t('settings.osc.params.profile.dialog.title.edit') }}</v-card-title>
+          <v-card-text>
+            <v-row>
+              <v-col :cols="12">
+                <v-text-field
+                  v-model="new_profile_name"
+                  :label="$t('settings.osc.params.profile.dialog.field_label')"
+                  hide-details
+                />
+              </v-col>
+            </v-row>
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn @click="closeEditProfileDialog">
+              {{ $t('settings.osc.params.button.cancel') }}
+            </v-btn>
+            <v-btn color="primary" @click="confirmEditProfileDialog">
               {{ $t('settings.osc.params.button.confirm') }}
             </v-btn>
           </v-card-actions>
         </v-card>
       </v-dialog>
     </v-row>
+
     <!-- Profile Delete Dialog -->
     <v-row justify="center">
       <v-dialog v-model="profile_delete_dialog" width="50vw">
@@ -152,183 +246,21 @@
             <v-btn @click="profile_delete_dialog = false">
               {{ $t('settings.osc.params.button.cancel') }}
             </v-btn>
-            <v-btn color="primary" @click="delete_profile_final()">
+            <v-btn color="primary" @click="confirmDeleteProfileDialog()">
               {{ $t('settings.osc.params.button.delete') }}
             </v-btn>
           </v-card-actions>
         </v-card>
       </v-dialog>
     </v-row>
+
     <!-- Param Trigger Dialog -->
     <v-row justify="center">
-      <v-dialog v-model="param_dialog" width="50vw" persistent>
-        <v-card>
-          <v-card-title v-if="!param_editing">{{ $t('settings.osc.params.param.dialog_title.add') }}</v-card-title>
-          <v-card-title v-else>{{ $t('settings.osc.params.param.dialog_title.edit') }}</v-card-title>
-          <v-card-text>
-            <v-row>
-              <!-- <v-col :cols="12">
-                                <v-text-field v-model="new_param.name" label="Name" hide-details></v-text-field>
-                            </v-col> -->
-              <v-col :cols="12">
-                <v-text-field v-model="new_param.route" :label="$t('settings.osc.params.param.address')" hide-details />
-              </v-col>
-              <v-col :cols="12" :md="6">
-                <v-text-field v-model="new_param.ip" label="OSC IP" hide-details />
-              </v-col>
-              <v-col>
-                <v-text-field v-model="new_param.port" label="OSC port" hide-details />
-              </v-col>
-            </v-row>
-          </v-card-text>
-
-          <v-divider class="mx-4" />
-
-          <v-card-text class="mt-2">
-            <v-row>
-              <!-- <v-col :cols="12"><strong>Trigger phrases</strong></v-col> -->
-              <v-col>
-                <strong v-html="$t('settings.osc.params.param.trigger_phrases')"></strong>
-                <v-chip v-if="!new_param.keywords.length" variant="text">
-                  {{ $t('settings.osc.params.param.empty') }}
-                </v-chip>
-                <v-chip
-                  v-else v-model="keyword.enabled"
-                  v-for="(keyword, i) in new_param.keywords"
-                  class="mx-1 mb-2"
-                  label
-                  color="secondary"
-                  size="small"
-                  closable
-                  @click:close="remove_trigger(i)"
-                >
-                  {{ keyword.text }}
-                </v-chip>
-              </v-col>
-              <v-col :cols="12">
-                <v-text-field
-                  v-model="trigger_phrase"
-                  :label="$t('settings.osc.params.param.trigger_phrases_add')"
-                  hide-details
-                  append-icon="mdi-plus"
-                  @click:append="add_trigger"
-                  @keydown.enter="add_trigger"
-                />
-              </v-col>
-            </v-row>
-          </v-card-text>
-
-          <v-divider class="mx-4" />
-
-          <v-card-text class="mt-2">
-            <v-row>
-              <v-col :cols="12">
-                <strong v-html="$t('settings.osc.params.param.assign_phrases')"></strong>
-                <v-chip v-if="!new_param.assigns.length" variant="text">
-                  {{ $t('settings.osc.params.param.empty') }}
-                </v-chip>
-                <v-list density="compact">
-                  <v-list-item
-                    v-for="(assign, i) in new_param.assigns"
-                    :value="assign"
-                    :title="assign.keyword"
-                    :subtitle="`set ${assign.type} to ${assign.set}`"
-                    @click="remove_assign(i)"
-                    class="assignment-editable"
-                  />
-                </v-list>
-              </v-col>
-              <v-col :cols="12" :lg="4">
-                <v-select
-                  v-model="new_assign.type"
-                  :items="var_types"
-                  hide-details
-                  :label="$t('settings.osc.params.param.assign_phrases_type')"
-                  @update:modelValue="validate_assign_value_field"
-                />
-              </v-col>
-              <v-col :cols="12" :lg="8">
-                <v-text-field
-                  v-if="new_assign.type !== 'bool'"
-                  v-model="new_assign.set"
-                  hide-details
-                  :label="$t('settings.osc.params.param.assign_phrases_value')"
-                  type="number"
-                  @input="validate_assign_value_field"
-                />
-                <v-select
-                  v-else
-                  v-model="new_assign.set"
-                  :items="['true', 'false']"
-                  hide-details
-                  :label="$t('settings.osc.params.param.assign_phrases_value')"
-                />
-              </v-col>
-              <v-col :cols="12">
-                <v-text-field
-                  v-model="new_assign.keyword"
-                  :label="$t('settings.osc.params.param.assign_phrases_add')"
-                  hide-details
-                  append-icon="mdi-plus"
-                  @click:append="add_assign"
-                  @keydown.enter="add_assign"
-                />
-              </v-col>
-            </v-row>
-          </v-card-text>
-
-          <v-divider class="mx-4" />
-
-          <v-card-text class="mt-2">
-            <v-row>
-              <v-col :cols="12">
-                <strong v-html="$t('settings.osc.params.param.behavior')"></strong>
-              </v-col>
-              <v-col :cols="6">
-                <v-select
-                  v-model="new_param.activation_signal"
-                  :items="[
-                    { name: $t('settings.osc.params.param.activation_signal_options.constant'), value: 'constant' },
-                    { name: $t('settings.osc.params.param.activation_signal_options.pulse'), value: 'pulse' }
-                  ]"
-                  item-title="name"
-                  item-value="value"
-                  hide-details
-                  :label="$t('settings.osc.params.param.activation_signal')"
-                />
-              </v-col>
-              <v-col :cols="6">
-                <v-text-field
-                  v-if="new_param.activation_signal === 'pulse'"
-                  v-model="new_param.pulse_delay"
-                  hide-details
-                  :label="$t('settings.osc.params.param.activation_signal_options.pulse_duration')"
-                  type="number"
-                  @input="new_param.pulse_delay = Math.round(new_param.pulse_delay)"
-                />
-              </v-col>
-            </v-row>
-          </v-card-text>
-
-          <v-divider class="mt-4" />
-
-          <div v-if="new_param.keywords.length && new_param.assigns.length" class="ma-2">
-            <v-list-item
-              :title="`Example phrase: 'set ${new_param.keywords[0]?.text} to ${new_param.assigns[0]?.keyword}'`"
-              :subtitle="`${new_param.route} -> ${new_param.assigns[0]?.set}`"
-            />
-          </div>
-          <v-card-actions>
-            <v-spacer />
-            <v-btn @click="closeParamDialog">
-              {{ $t('settings.osc.params.button.cancel') }}
-            </v-btn>
-            <v-btn color="primary" @click="confirm_param">
-              {{ $t('settings.osc.params.button.confirm') }}
-            </v-btn>
-          </v-card-actions>
-        </v-card>
-      </v-dialog>
+      <ParameterTrigger
+        v-model="param_dialog"
+        :mode="param_dialog_mode"
+        :editing-index="param_editing_index"
+      />
     </v-row>
   </v-card>
 </template>
@@ -344,23 +276,12 @@
 </style>
 
 <script lang="ts">
+import ParameterTrigger from '@/components/settings/oscparams/dialogs/ParameterTrigger.vue'
 import { useOSCStore } from '@/stores/osc'
-
-interface Param {
-  route: string
-}
-interface Keyword {
-  enabled: boolean
-  text: string
-}
-interface Assign {
-  keyword: string
-  type: string
-  set: string // Receive user-input as a string. Parse it when finally sending a payload.
-}
 
 export default {
   name: 'SettingsGeneral',
+  components: { ParameterTrigger },
   setup() {
     const oscStore = useOSCStore()
 
@@ -375,45 +296,22 @@ export default {
     }
   },
   data: () => ({
-    profile_dialog: false,
     new_profile_name: '',
-
-    profile_editing: false,
-    profile_editing_key: '',
-
+    
+    profile_add_dialog: false,
+    
+    profile_edit_dialog: false,
+    editing_profile_name: '',
+    
     profile_delete_dialog: false,
     profile_delete_target: '',
-
+    
     param_dialog: false,
-
-    param_editing: false,
-    param_editing_index: 0,
-
-    trigger_phrase: '',
-
-    var_types: ['bool', 'int', 'float'],
-    new_assign: {
-      keyword: '',
-      type: 'bool',
-      set: 'true',
-    },
-
-    new_param: {
-      // name: '',
-      ip: '',
-      port: '',
-      route: '/avatar/parameters/',
-      keywords: [] as Keyword[], // [{enabled: boolean, text: string}?],
-      assigns: [] as Assign[], // [{keyword: string, type: string, set: string}?]
-
-      // "constant" (Default): set the parameter to this value.
-      // "pulse": set the parameter to this value, then reset it (0, 0.0, false) after some time.
-      activation_signal: 'constant',
-      pulse_delay: 0,
-    },
+    param_dialog_mode: '', // "add", "edit"
+    param_editing_index: NaN,
   }),
   computed: {
-    sorted_profiles() {
+    sortedProfiles() {
       return Object.keys(this.oscStore.osc_profiles).sort((a, b) => {
         if (a === "Default")
           return -1 // The profile "Default" is always first.
@@ -428,55 +326,60 @@ export default {
     openAddProfileDialog() {
       this.new_profile_name = ''
 
-      this.profile_dialog = true
+      this.profile_add_dialog = true
     },
-    confirmNewProfile() {
-      if (!this.new_profile_name.trim()) {
+    confirmAddProfileDialog() {
+      if (!this.new_profile_name.trim()) // The profile name field is empty.
         return
-      }
 
       if (this.new_profile_name in this.oscStore.osc_profiles) // The profile name is already being used.
         return
 
-      if (this.profile_editing) {
-        this.oscStore.osc_profiles[this.new_profile_name] = this.oscStore.osc_profiles[this.profile_editing_key]
+      this.oscStore.osc_profiles[this.new_profile_name] = []
+      this.oscStore.current_profile = this.new_profile_name
 
-        if (this.oscStore.current_profile === this.profile_editing_key)
-          this.oscStore.current_profile = this.new_profile_name
+      this.new_profile_name = '' // Reset the dialog's field.
 
-        delete this.oscStore.osc_profiles[this.profile_editing_key]
-
-        this.profile_editing = false
-      }
-      else {
-        this.oscStore.osc_profiles[this.new_profile_name] = []
-        this.oscStore.current_profile = this.new_profile_name
-      }
-
-      // Reset the dialog's field.
-      this.new_profile_name = ''
-
-      this.profile_dialog = false
+      this.profile_add_dialog = false
     },
-    openRenameProfileDialog(profile_name: string) {
-      this.profile_editing = true
-      this.profile_editing_key = profile_name
+    closeAddProfileDialog()
+    {
+      this.profile_add_dialog = false
+    },
+    openEditProfileDialog(profile_name: string) {
+      this.editing_profile_name = profile_name
       this.new_profile_name = profile_name
 
-      this.profile_dialog = true
+      this.profile_edit_dialog = true
     },
-    closeProfileDialog()
+    confirmEditProfileDialog() {
+      if (!this.new_profile_name.trim()) // The profile name field is empty.
+        return
+
+      if (this.new_profile_name in this.oscStore.osc_profiles) // The profile name is already being used.
+        return
+
+      this.oscStore.osc_profiles[this.new_profile_name] = this.oscStore.osc_profiles[this.editing_profile_name]
+
+      if (this.oscStore.current_profile === this.editing_profile_name)
+        this.oscStore.current_profile = this.new_profile_name
+
+      delete this.oscStore.osc_profiles[this.editing_profile_name]
+
+      this.new_profile_name = '' // Reset the dialog's field.
+
+      this.profile_edit_dialog = false
+    },
+    closeEditProfileDialog()
     {
-      this.profile_editing = false
-      this.profile_dialog = false
+      this.profile_edit_dialog = false
     },
-    delete_profile(profile_name: string) {
+    openDeleteProfileDialog(profile_name: string) {
       this.profile_delete_target = profile_name
 
       this.profile_delete_dialog = true
     },
-    delete_profile_final()
-    {
+    confirmDeleteProfileDialog() {
       if (this.oscStore.current_profile === this.profile_delete_target)
         this.oscStore.current_profile = "Default"
 
@@ -485,125 +388,15 @@ export default {
       this.profile_delete_dialog = false
     },
     openAddParamDialog() {
-      // Reset the dialog's fields.
-      this.new_param = {
-        ip: this.oscStore.ip,
-        port: this.oscStore.port,
-        route: '/avatar/parameters/',
-        keywords: [],
-        assigns: [],
-        activation_signal: 'constant',
-        pulse_delay: 1000,
-      }
-
-      this.trigger_phrase = ''
-      
-      this.new_assign = {
-        keyword: '',
-        type: 'bool',
-        set: 'true',
-      }
-
-      // Open the dialog.
+      this.param_dialog_mode = "add"
       this.param_dialog = true
     },
     openEditParamDialog(i: number) {
-      this.openAddParamDialog()
-
-      this.param_editing = true
+      this.param_dialog_mode = "edit"
       this.param_editing_index = i
-
-      const existingParam = this.oscStore.osc_profiles[this.oscStore.current_profile][i]
-      this.new_param = JSON.parse(JSON.stringify(existingParam)) // Deep copy.
+      this.param_dialog = true
     },
-    closeParamDialog()
-    {
-      this.param_editing = false
-      this.param_dialog = false
-    },
-    validate_assign_value_field() {
-      const assign = this.new_assign
-
-      switch (assign.type) {
-        case 'int':
-          if (assign.set === "" || isNaN(Number(assign.set))) // Invalid input.
-            assign.set = "0"
-          else { // Valid input.
-            // Display.
-            assign.set = String(parseInt(assign.set))
-          }
-
-          break
-        case 'float':
-          if (assign.set === "" || isNaN(Number(assign.set))) // Invalid input.
-            assign.set = "0"
-          else { // Valid input.
-            // Display.
-            assign.set = assign.set.replace(/^0+(?=\d)/, '') // Remove leading zeros in front of the number.
-          }
-
-          break
-        case 'bool':
-          if (assign.set !== "true" && assign.set !== "false") // Invalid input.
-            assign.set = "true"
-
-          break
-      }
-    },
-    add_trigger() {
-      if (!this.trigger_phrase.trim()) // The trigger phrase field is empty.
-        return
-
-      this.new_param.keywords.push({ enabled: true, text: this.trigger_phrase })
-
-      this.trigger_phrase = ''
-    },
-    remove_trigger(i: number) {
-      this.new_param.keywords.splice(i, 1)
-    },
-    add_assign() {
-      const assign = this.new_assign
-
-      // Validation.
-      if (!assign.keyword.trim()) // The assign keyword field is empty.
-        return
-
-      // Display.
-      if (assign.type === "float") {
-        if (!assign.set.includes('.')) { // 123 → 123.0
-          assign.set = assign.set + ".0"
-        }
-        else if (assign.set.endsWith('.')) { // 123. → 123.0
-          assign.set = assign.set + "0"
-        }
-      }
-
-      // Store.
-      this.new_param.assigns.push(assign)
-
-      // Partially reset the assign fields.
-      this.new_assign = {
-        keyword: '',
-        type: assign.type,
-        set: assign.set,
-      }
-    },
-    remove_assign(i: number) {
-      this.new_param.assigns.splice(i, 1)
-    },
-    confirm_param() {
-      if (!this.param_editing) {
-        this.oscStore.osc_profiles[this.oscStore.current_profile].push(this.new_param)
-      }
-      else {
-        this.oscStore.osc_profiles[this.oscStore.current_profile][this.param_editing_index] = JSON.parse(JSON.stringify(this.new_param)) // Deep copy.
-
-        this.param_editing = false
-      }
-
-      this.param_dialog = false
-    },
-    delete_param(i: number) {
+    deleteParam(i: number) {
       this.oscStore.osc_profiles[this.oscStore.current_profile].splice(i, 1)
     },
   },

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -29,24 +29,24 @@
                   <v-list-item-title class="flex-grow-1">
                     {{ item.title }}
                   </v-list-item-title>
-                  <v-list-item-action>
+                  <v-list-item-action v-if="item.title !== 'Default'">
                     <v-btn
                       icon
                       variant="plain"
                       density="comfortable"
                       @click.stop="openEditProfileDialog(item.title)"
                     >
-                      <v-icon v-if="item.title !== 'Default'">mdi-pencil-outline</v-icon>
+                      <v-icon>mdi-pencil-outline</v-icon>
                     </v-btn>
                   </v-list-item-action>
-                  <v-list-item-action class="ml-2">
+                  <v-list-item-action v-if="item.title !== 'Default'" class="ml-2">
                     <v-btn
                       icon
                       variant="plain"
                       density="comfortable"
                       @click.stop="openDeleteProfileDialog(item.title)"
                     >
-                      <v-icon v-if="item.title !== 'Default'">mdi-close</v-icon>
+                      <v-icon>mdi-close</v-icon>
                     </v-btn>
                   </v-list-item-action>
                 </div>
@@ -66,14 +66,22 @@
       </v-row>
 
       <!-- Parameter Triggers -->
-      <v-card
+      <v-expansion-panels
         v-if="Object.keys(oscStore.osc_profiles[oscStore.current_profile]).length > 0"
         v-for="(param, i) in oscStore.osc_profiles[oscStore.current_profile]"
         class="mb-4"
       >
-        <v-card color="rgba(0, 0, 0, 0)">
-          <v-card-title class="d-flex align-center">
-            {{ param.route }}
+        <v-expansion-panel>
+          <v-expansion-panel-title ripple class="param d-flex align-center">
+            <v-text-field
+              v-model="param.route"
+              variant="plain"
+              flat
+              density="compact"
+              hide-details
+              readonly
+              class="param-route w-100"
+            />
             <v-spacer />
             <v-btn
               class="ml-4"
@@ -82,86 +90,92 @@
               size="small"
               color="primary"
               append-icon="mdi-pencil"
-              @click="openEditParamDialog(i)"
+              @click.stop="openEditParamDialog(i)"
             >
               {{ $t('settings.osc.params.param.button.edit') }}
             </v-btn>
             <v-btn
-              class="ml-4"
+              class="ml-4 mr-4"
               flat variant="text"
               size="small"
               color="error"
               append-icon="mdi-delete"
-              @click="deleteParam(i)"
+              @click.stop="deleteParam(i)"
             >
               {{ $t('settings.osc.params.param.button.delete') }}
             </v-btn>
-          </v-card-title>
-          <v-divider />
-          <v-card-text>
-            <v-row>
-              <!-- <v-col :cols="12">
-                <v-text-field v-model="param.name" label="Name" hide-details></v-text-field>
-              </v-col> -->
-              <v-col :cols="12" :md="6">
-                <v-text-field
-                  v-model="param.ip"
-                  :label="$t('settings.osc.general.osc_ip')"
-                  variant="outlined"
-                  hide-details readonly
-                />
-              </v-col>
-              <v-col>
-                <v-text-field
-                  v-model="param.port"
-                  :label="$t('settings.osc.general.osc_port')"
-                  variant="outlined"
-                  hide-details
-                  readonly
-                />
-              </v-col>
+          </v-expansion-panel-title>
+          <v-expansion-panel-text>
+            <v-card flat>
+              <v-card-text>
+                <v-row>
+                  <!-- <v-col :cols="12">
+                    <v-text-field v-model="param.name" label="Name" hide-details></v-text-field>
+                  </v-col> -->
+                  <v-col :cols="12" :md="6">
+                    <v-text-field
+                      v-model="param.ip"
+                      :label="$t('settings.osc.general.osc_ip')"
+                      flat
+                      variant="solo-filled"
+                      hide-details
+                      readonly
+                    />
+                  </v-col>
+                  <v-col>
+                    <v-text-field
+                      v-model="param.port"
+                      :label="$t('settings.osc.general.osc_port')"
+                      flat
+                      variant="solo-filled"
+                      hide-details
+                      readonly
+                    />
+                  </v-col>
 
-              <v-col :cols="12">
-                <strong v-html="$t('settings.osc.params.param.trigger_phrases')"></strong>
-              </v-col>
-              <v-col :cols="12">
-                <v-chip
-                  v-for="(keyword, i) in param.keywords"
-                  v-model="keyword.enabled"
-                  class="mx-1 mb-2"
-                  label
-                  color="secondary"
-                  size="small"
-                >
-                  {{ keyword.text }}
-                </v-chip>
-              </v-col>
-              <v-col :cols="12">
-                <strong v-html="$t('settings.osc.params.param.assign_phrases')"></strong>
-                <v-list density="compact">
-                  <v-list-item
-                    v-for="(assign, i) in param.assigns"
-                    :value="assign"
-                    :title="assign.keyword"
-                    :subtitle="`set ${assign.type} to ${assign.set}`"
-                    class="display-only"
-                  />
-                </v-list>
-              </v-col>
-              <v-col :cols="12">
-                <strong v-html="$t('settings.osc.params.param.behavior')"></strong>
-                <v-list density="compact">
-                  <v-list-item
-                    :value="param"
-                    :title="`${$t('settings.osc.params.param.activation_signal_options.' + param.activation_signal)}${param.activation_signal === 'pulse' ? ` (${param.pulse_delay}ms)` : ''}`"
-                    class="display-only"
-                  />
-                </v-list>
-              </v-col>
-            </v-row>
-          </v-card-text>
-        </v-card>
-      </v-card>
+                  <v-col :cols="12">
+                    <strong v-html="$t('settings.osc.params.param.trigger_phrases')"></strong>
+                  </v-col>
+                  <v-col :cols="12">
+                    <v-chip
+                      v-for="(keyword, i) in param.keywords"
+                      v-model="keyword.enabled"
+                      class="mx-1 mb-2"
+                      label
+                      color="secondary"
+                      size="small"
+                    >
+                      {{ keyword.text }}
+                    </v-chip>
+                  </v-col>
+                  <v-col :cols="12">
+                    <strong v-html="$t('settings.osc.params.param.assign_phrases')"></strong>
+                    <v-list density="compact">
+                      <v-list-item
+                        v-for="(assign, i) in param.assigns"
+                        :value="assign"
+                        :title="assign.keyword"
+                        :subtitle="`set ${assign.type} to ${assign.set}`"
+                        class="display-only"
+                      />
+                    </v-list>
+                  </v-col>
+                  <v-col :cols="12">
+                    <strong v-html="$t('settings.osc.params.param.behavior')"></strong>
+                    <v-list density="compact">
+                      <v-list-item
+                        :value="param"
+                        :title="`${$t('settings.osc.params.param.activation_signal_options.' + param.activation_signal)}${param.activation_signal === 'pulse' ? ` (${param.pulse_delay}ms)` : ''}`"
+                        class="display-only"
+                      />
+                    </v-list>
+                  </v-col>
+                </v-row>
+              </v-card-text>
+            </v-card>
+          </v-expansion-panel-text>
+        </v-expansion-panel>
+      </v-expansion-panels>
       <p v-else v-html="$t('settings.osc.params.empty')"></p>
       <v-card class="mt-2" color="transparent" flat>
         <v-card-actions>
@@ -184,11 +198,19 @@
           <v-card-text>
             <v-row>
               <v-col :cols="12">
-                <v-text-field
-                  v-model="new_profile_name"
-                  :label="$t('settings.osc.params.profile.dialog.field_label')"
-                  hide-details
-                />
+                <v-form v-model="new_profile_name_valid" @submit.prevent="new_profile_name_valid ? confirmAddProfileDialog() : null">
+                  <v-text-field
+                    v-model="new_profile_name"
+                    :label="$t('settings.osc.params.profile.dialog.field_label')"
+                    :rules="[
+                      rules.required,
+                      rules.empty,
+                      rules.already_taken(new_profile_name, oscStore.osc_profiles)
+                    ]"
+                    autofocus
+                    spellcheck="false"
+                  />
+                </v-form>
               </v-col>
             </v-row>
           </v-card-text>
@@ -197,7 +219,11 @@
             <v-btn @click="closeAddProfileDialog">
               {{ $t('settings.osc.params.button.cancel') }}
             </v-btn>
-            <v-btn color="primary" @click="confirmAddProfileDialog">
+            <v-btn
+              color="primary"
+              @click="confirmAddProfileDialog"
+              :disabled="!new_profile_name_valid"  
+            >
               {{ $t('settings.osc.params.button.add') }}
             </v-btn>
           </v-card-actions>
@@ -213,11 +239,19 @@
           <v-card-text>
             <v-row>
               <v-col :cols="12">
-                <v-text-field
-                  v-model="new_profile_name"
-                  :label="$t('settings.osc.params.profile.dialog.field_label')"
-                  hide-details
-                />
+                <v-form v-model="new_profile_name_valid" @submit.prevent="new_profile_name_valid ? confirmEditProfileDialog() : null">
+                  <v-text-field
+                    v-model="new_profile_name"
+                    :label="$t('settings.osc.params.profile.dialog.field_label')"
+                    :rules="[
+                      rules.required,
+                      rules.empty,
+                      rules.already_taken(new_profile_name, oscStore.osc_profiles)
+                    ]"
+                    autofocus
+                    spellcheck="false"
+                  />
+                </v-form>
               </v-col>
             </v-row>
           </v-card-text>
@@ -226,7 +260,11 @@
             <v-btn @click="closeEditProfileDialog">
               {{ $t('settings.osc.params.button.cancel') }}
             </v-btn>
-            <v-btn color="primary" @click="confirmEditProfileDialog">
+            <v-btn
+              color="primary"
+              @click="confirmEditProfileDialog"
+              :disabled="!new_profile_name_valid"
+            >
               {{ $t('settings.osc.params.button.confirm') }}
             </v-btn>
           </v-card-actions>
@@ -266,6 +304,27 @@
 </template>
 
 <style>
+.v-expansion-panel-title__overlay {
+  background-color: initial !important;
+}
+
+.param:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.param-route {
+  /* This typography imitates Vuetify's class text-button. In the corresponding v-text-field, this class works, but Vuetify's class does not work. */
+  font-size: 0.875rem !important;
+  font-weight: 500;
+  line-height: 2.25rem;
+  letter-spacing: 0.0892857143em !important;
+}
+
+.param-route input {
+  padding: 0 !important;
+  cursor: pointer;
+}
+
 .display-only {
   pointer-events: none;
 }
@@ -297,6 +356,7 @@ export default {
   },
   data: () => ({
     new_profile_name: '',
+    new_profile_name_valid: false,
     
     profile_add_dialog: false,
     
@@ -309,6 +369,12 @@ export default {
     param_dialog: false,
     param_dialog_mode: '', // "add", "edit"
     param_editing_index: NaN,
+
+    rules: {
+      required: (value: string) => !!value || 'Required',
+      empty: (value: string) => !!value.trim() || 'Cannot be empty',
+      already_taken: (value: string, collection: object) => !(value in collection) || 'Already in use',
+    },
   }),
   computed: {
     sortedProfiles() {
@@ -323,22 +389,24 @@ export default {
     },
   },
   methods: {
+    clearFocus() {
+      const focusedElement = document.activeElement as HTMLElement
+
+      if (focusedElement)
+        focusedElement.blur()
+    },
     openAddProfileDialog() {
+      this.clearFocus()
+
       this.new_profile_name = ''
 
       this.profile_add_dialog = true
     },
     confirmAddProfileDialog() {
-      if (!this.new_profile_name.trim()) // The profile name field is empty.
-        return
-
-      if (this.new_profile_name in this.oscStore.osc_profiles) // The profile name is already being used.
-        return
-
       this.oscStore.osc_profiles[this.new_profile_name] = []
       this.oscStore.current_profile = this.new_profile_name
 
-      this.new_profile_name = '' // Reset the dialog's field.
+      this.new_profile_name = ''
 
       this.profile_add_dialog = false
     },
@@ -347,18 +415,14 @@ export default {
       this.profile_add_dialog = false
     },
     openEditProfileDialog(profile_name: string) {
+      this.clearFocus()
+
       this.editing_profile_name = profile_name
       this.new_profile_name = profile_name
 
       this.profile_edit_dialog = true
     },
     confirmEditProfileDialog() {
-      if (!this.new_profile_name.trim()) // The profile name field is empty.
-        return
-
-      if (this.new_profile_name in this.oscStore.osc_profiles) // The profile name is already being used.
-        return
-
       this.oscStore.osc_profiles[this.new_profile_name] = this.oscStore.osc_profiles[this.editing_profile_name]
 
       if (this.oscStore.current_profile === this.editing_profile_name)
@@ -366,12 +430,14 @@ export default {
 
       delete this.oscStore.osc_profiles[this.editing_profile_name]
 
-      this.new_profile_name = '' // Reset the dialog's field.
+      this.new_profile_name = ''
 
       this.profile_edit_dialog = false
     },
     closeEditProfileDialog()
     {
+      this.new_profile_name = ''
+
       this.profile_edit_dialog = false
     },
     openDeleteProfileDialog(profile_name: string) {

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -22,7 +22,7 @@
           >
             <template v-slot:item="{ item }">
               <v-list-item @click="oscStore.current_profile = item.title">
-                <v-list-item-content class="d-flex align-center">
+                <div class="d-flex align-center">
                   <v-list-item-title class="flex-grow-1">
                     {{ item.title }}
                   </v-list-item-title>
@@ -36,7 +36,7 @@
                       <v-icon v-if="item.title !== 'Default'">mdi-close</v-icon>
                     </v-btn>
                   </v-list-item-action>
-                </v-list-item-content>
+                </div>
               </v-list-item>
             </template>
           </v-select>

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -24,7 +24,7 @@
             :menu-props="{ closeOnContentClick: true }"
           >
             <template v-slot:item="{ item }">
-              <v-list-item @click="oscStore.current_profile = item.title">
+              <v-list-item @click="setProfile(item.title)">
                 <div class="d-flex align-center">
                   <v-list-item-title class="flex-grow-1">
                     {{ item.title }}
@@ -68,10 +68,13 @@
       <!-- Parameter Triggers -->
       <v-expansion-panels
         v-if="Object.keys(oscStore.osc_profiles[oscStore.current_profile]).length > 0"
-        v-for="(param, i) in oscStore.osc_profiles[oscStore.current_profile]"
-        class="mb-4"
+        v-model="param_panels"
+        multiple
       >
-        <v-expansion-panel>
+        <v-expansion-panel
+          v-for="(param, i) in oscStore.osc_profiles[oscStore.current_profile]"
+          class="mb-4"
+        >
           <v-expansion-panel-title ripple class="param d-flex align-center">
             <v-text-field
               v-model="param.route"
@@ -314,6 +317,14 @@
 </template>
 
 <style>
+.v-expansion-panel:not(:first-child)::after {
+  border: none !important;
+}
+
+.v-expansion-panel {
+  margin-top: 0 !important;
+}
+
 .v-expansion-panel-title__overlay {
   background-color: initial !important;
 }
@@ -370,7 +381,7 @@ export default {
       empty: (value: string) => !!value.trim() || 'Cannot be empty',
       already_taken: (value: string, collection: object) => !(value in collection) || 'Already in use',
     },
-    
+   
     new_profile_name: '',
     new_profile_name_valid: false,
     
@@ -382,6 +393,8 @@ export default {
     profile_delete_dialog: false,
     profile_delete_target: '',
     
+    param_panels: [],
+
     param_dialog: false,
     param_dialog_mode: '', // "add", "edit"
     
@@ -465,6 +478,11 @@ export default {
       delete this.oscStore.osc_profiles[this.profile_delete_target]
 
       this.profile_delete_dialog = false
+    },
+    setProfile(selected_profile: string) {
+      this.oscStore.current_profile = selected_profile
+
+      this.param_panels = [] // Collapse all parameter trigger expansion panels.
     },
     displayAssignSubtitle(assign_object: any) {
       let subtitle = `set ${assign_object.type} to ${assign_object.set1}`

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -56,6 +56,15 @@
                   />
                 </v-list>
               </v-col>
+              <v-col :cols="12">
+                <strong>Behavior:</strong>
+                <v-list density="compact">
+                  <v-list-item
+                    :value="param"
+                    :title="param.behavior"
+                  />
+                </v-list>
+              </v-col>
             </v-row>
           </v-card-text>
         </v-card>
@@ -122,7 +131,6 @@
 
           <v-card-text class="mt-2">
             <v-row>
-              <!-- <v-col :cols="12"><strong>Trigger phrases</strong></v-col> -->
               <v-col :cols="12">
                 <strong>Assign phrases:</strong>
                 <v-chip v-if="!new_param.assigns.length" variant="text">
@@ -159,7 +167,21 @@
             </v-row>
           </v-card-text>
 
+          <v-divider class="mx-4" />
+
+          <v-card-text class="mt-2">
+            <v-row>
+              <v-col :cols="12">
+                <strong>Behavior:</strong>
+              </v-col>
+              <v-col :cols="12">
+                <v-select v-model="new_param.behavior" :items="['Constant', 'Pulse'] as string[]" hide-details label="Activation signal" />
+              </v-col>
+            </v-row>
+          </v-card-text>
+
           <v-divider class="mt-4" />
+
           <div v-if="new_param.keywords.length && new_param.assigns.length" class="ma-2">
             <v-list-item
               :title="`Example phrase: 'set ${new_param.keywords[0]?.text} to ${new_param.assigns[0]?.keyword}'`"
@@ -244,6 +266,11 @@ export default {
       route: '/avatar/parameters/',
       keywords: [] as Keyword[], // [{enabled: boolean, text: string}?],
       assigns: [] as Assign[], // [{keyword: string, type: string, set: string}?]
+
+      // The behavior or activation signal of the param trigger.
+      // "Constant" (Default): set the parameter to this value.
+      // "Pulse": set the parameter to this value, then reset it (0, 0.0, false) after some time.
+      behavior: 'Constant',
     },
   }),
   methods: {
@@ -255,6 +282,7 @@ export default {
         route: '/avatar/parameters/',
         keywords: [],
         assigns: [],
+        behavior: 'Constant',
       }
 
       this.trigger_phrase = ''

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -108,7 +108,7 @@
               <v-col :cols="12">
                 <v-text-field
                   v-model="trigger_phrase"
-                  label="Add trigger word"
+                  label="Add trigger word/phrase"
                   hide-details
                   append-icon="mdi-plus"
                   @click:append="add_trigger"

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -37,7 +37,7 @@
           </v-select>
         </v-col>
         <v-card-actions class="pa-3" style="height: 80px">
-          <v-btn color="primary" variant="outlined" size="small" icon="mdi-plus" @click="profile_dialog = true" />
+          <v-btn color="primary" variant="outlined" size="small" icon="mdi-plus" @click="openAddProfileDialog" />
         </v-card-actions>
       </v-row>
       <v-card v-if="Object.keys(oscStore.osc_profiles[oscStore.current_profile]).length > 0" v-for="(param, i) in oscStore.osc_profiles[oscStore.current_profile]" class="mb-4">
@@ -103,7 +103,7 @@
       </p>
       <v-card class="mt-2" color="transparent" flat>
         <v-card-actions>
-          <v-btn color="primary" variant="outlined" size="small" icon="mdi-plus" @click="openAddDialog" />
+          <v-btn color="primary" variant="outlined" size="small" icon="mdi-plus" @click="openAddParamDialog" />
         </v-card-actions>
       </v-card>
     </v-card-text>
@@ -352,6 +352,11 @@ export default {
     },
   }),
   methods: {
+    openAddProfileDialog() {
+      this.new_profile_name = ''
+
+      this.profile_dialog = true
+    },
     confirmNewProfile() {
       if (!this.new_profile_name.trim()) {
         return
@@ -368,7 +373,7 @@ export default {
 
       this.profile_dialog = false
     },
-    openAddDialog() {
+    openAddParamDialog() {
       // Reset the dialog's fields.
       this.new_param = {
         ip: this.oscStore.ip,
@@ -391,7 +396,7 @@ export default {
       this.param_dialog = true
     },
     openEditDialog(i: number) {
-      this.openAddDialog()
+      this.openAddParamDialog()
 
       this.editing = true
       this.editing_index = i

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -81,7 +81,7 @@
                     :value="assign"
                     :title="assign.keyword"
                     :subtitle="`set ${assign.type} to ${assign.set}`"
-                    class="assignment-display"
+                    class="display-only"
                   />
                 </v-list>
               </v-col>
@@ -91,6 +91,7 @@
                   <v-list-item
                     :value="param"
                     :title="`${param.activation_signal}${param.activation_signal === 'Pulse' ? ` (${param.pulse_delay}ms)` : ''}`"
+                    class="display-only"
                   />
                 </v-list>
               </v-col>
@@ -279,7 +280,7 @@
 </template>
 
 <style>
-.assignment-display {
+.display-only {
   pointer-events: none;
 }
 

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -287,7 +287,7 @@ export default {
 
       switch (assign.type) {
         case 'int':
-          if (assign.set == '' || isNaN(Number(assign.set))) // Invalid input.
+          if (assign.set === "" || isNaN(Number(assign.set))) // Invalid input.
             assign.set = "0"
           else { // Valid input.
             // Display.
@@ -296,26 +296,28 @@ export default {
 
           break
         case 'float':
-          if (assign.set == '' || isNaN(Number(assign.set))) // Invalid input.
+          if (assign.set === "" || isNaN(Number(assign.set))) // Invalid input.
             assign.set = "0"
           else { // Valid input.
             // Display.
-            assign.set = String(parseFloat(assign.set))
+            assign.set = assign.set.replace(/^0+(?=\d)/, '') // Remove leading zeros in front of the number.
           }
-          
+
           break
         case 'bool':
-          if (assign.set !== 'true' && assign.set !== 'false')
+          if (assign.set !== "true" && assign.set !== "false") // Invalid input.
             assign.set = "true"
 
           break
       }
     },
     add_trigger() {
-      if (this.trigger_phrase !== '') {
-        this.new_param.keywords.push({ enabled: true, text: this.trigger_phrase })
-        this.trigger_phrase = ''
-      }
+      if (!this.trigger_phrase.trim()) // The trigger phrase field is empty.
+        return
+
+      this.new_param.keywords.push({ enabled: true, text: this.trigger_phrase })
+
+      this.trigger_phrase = ''
     },
     remove_trigger(i: number) {
       this.new_param.keywords.splice(i, 1)
@@ -324,9 +326,20 @@ export default {
       const assign = this.new_assign
 
       // Validation.
-      if (assign.keyword == '') // The assign keyword field is empty.
+      if (!assign.keyword.trim()) // The assign keyword field is empty.
         return
 
+      // Display.
+      if (assign.type === "float") {
+        if (!assign.set.includes('.')) { // 123 → 123.0
+          assign.set = assign.set + ".0"
+        }
+        else if (assign.set.endsWith('.')) { // 123. → 123.0
+          assign.set = assign.set + "0"
+        }
+      }
+
+      // Store.
       this.new_param.assigns.push(assign)
 
       // Partially reset the assign fields.

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -224,7 +224,7 @@
     <!-- Profile Edit Dialog -->
     <v-row justify="center">
       <v-dialog v-model="profile_edit_dialog" width="50vw">
-        <v-card v-click-outside="confirmEditProfileDialog">
+        <v-card v-click-outside="closeEditProfileDialog">
           <v-card-title>{{ $t('settings.osc.params.profile.dialog.title.edit') }}</v-card-title>
           <v-card-text>
             <v-row>
@@ -451,8 +451,6 @@ export default {
     },
     closeEditProfileDialog()
     {
-      this.new_profile_name = ''
-
       this.profile_edit_dialog = false
     },
     openDeleteProfileDialog(profile_name: string) {

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -3,7 +3,7 @@
     <template v-slot:title>
       <span v-html="$t('settings.osc.params.title')"></span>
       <v-chip prepend-icon="mdi-alert-circle-outline" color="warning" class="ml-2" variant="elevated" size="small">
-        Subject to change
+        {{ $t('general.subject_to_change') }}
       </v-chip>
     </template>
     <template v-slot:subtitle>

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -149,23 +149,13 @@
                     </v-chip>
                   </v-col>
                   <v-col :cols="12">
-                    <strong v-html="$t('settings.osc.params.param.assign_phrases')"></strong>
+                    <strong v-html="$t('settings.osc.params.param.assign.phrases')"></strong>
                     <v-list density="compact">
                       <v-list-item
                         v-for="(assign, i) in param.assigns"
                         :value="assign"
                         :title="assign.keyword"
-                        :subtitle="`set ${assign.type} to ${assign.set}`"
-                        class="display-only"
-                      />
-                    </v-list>
-                  </v-col>
-                  <v-col :cols="12">
-                    <strong v-html="$t('settings.osc.params.param.behavior')"></strong>
-                    <v-list density="compact">
-                      <v-list-item
-                        :value="param"
-                        :title="`${$t('settings.osc.params.param.activation_signal_options.' + param.activation_signal)}${param.activation_signal === 'pulse' ? ` (${param.pulse_delay}ms)` : ''}`"
+                        :subtitle="displayAssignSubtitle(assign)"
                         class="display-only"
                       />
                     </v-list>
@@ -355,6 +345,12 @@ export default {
     }
   },
   data: () => ({
+    rules: {
+      required: (value: string) => !!value || 'Required',
+      empty: (value: string) => !!value.trim() || 'Cannot be empty',
+      already_taken: (value: string, collection: object) => !(value in collection) || 'Already in use',
+    },
+    
     new_profile_name: '',
     new_profile_name_valid: false,
     
@@ -369,12 +365,6 @@ export default {
     param_dialog: false,
     param_dialog_mode: '', // "add", "edit"
     param_editing_index: NaN,
-
-    rules: {
-      required: (value: string) => !!value || 'Required',
-      empty: (value: string) => !!value.trim() || 'Cannot be empty',
-      already_taken: (value: string, collection: object) => !(value in collection) || 'Already in use',
-    },
   }),
   computed: {
     sortedProfiles() {
@@ -452,6 +442,14 @@ export default {
       delete this.oscStore.osc_profiles[this.profile_delete_target]
 
       this.profile_delete_dialog = false
+    },
+    displayAssignSubtitle(assign_object: any) {
+      let subtitle = `set ${assign_object.type} to ${assign_object.set1}`
+
+      if (assign_object.activation === 'pulse')
+        subtitle = subtitle + `, wait ${assign_object.pulse_duration}ms, set ${assign_object.type} to ${assign_object.set2}`
+
+      return subtitle
     },
     openAddParamDialog() {
       this.param_dialog_mode = "add"

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -1,14 +1,14 @@
 <template>
   <v-card color="transparent" flat>
-    <v-card-title>
-      Custom Params
-      <v-chip prepend-icon="mdi-alert-circle-outline" color="warning" class="ml-2" variant="elevated">
+    <template v-slot:title>
+      <span v-html="$t('settings.osc.params.title')"></span>
+      <v-chip prepend-icon="mdi-alert-circle-outline" color="warning" class="ml-2" variant="elevated" size="small">
         Subject to change
       </v-chip>
-    </v-card-title>
-    <v-card-subtitle class="overflow-hidden">
-      Add custom param triggers here.
-    </v-card-subtitle>
+    </template>
+    <template v-slot:subtitle>
+      <span>Add custom param triggers here</span>
+    </template>
     <v-divider />
     <v-card-text>
       <v-card v-for="(param, i) in oscStore.osc_params" v-if="oscStore.osc_params.length" class="mb-4">

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -90,7 +90,7 @@
                 <v-list density="compact">
                   <v-list-item
                     :value="param"
-                    :title="param.behavior"
+                    :title="`${param.activation_signal}${param.activation_signal === 'Pulse' ? ` (${param.pulse_delay}ms)` : ''}`"
                   />
                 </v-list>
               </v-col>
@@ -246,8 +246,11 @@
               <v-col :cols="12">
                 <strong>Behavior:</strong>
               </v-col>
-              <v-col :cols="12">
-                <v-select v-model="new_param.behavior" :items="['Constant', 'Pulse'] as string[]" hide-details label="Activation signal" />
+              <v-col :cols="6">
+                <v-select v-model="new_param.activation_signal" :items="['Constant', 'Pulse'] as string[]" hide-details label="Activation signal" />
+              </v-col>
+              <v-col :cols="6">
+                <v-text-field v-if="new_param.activation_signal === 'Pulse'" v-model="new_param.pulse_delay" hide-details label="Pulse duration (milliseconds)" type="number" @input="new_param.pulse_delay = Math.round(new_param.pulse_delay)" />
               </v-col>
             </v-row>
           </v-card-text>
@@ -345,10 +348,10 @@ export default {
       keywords: [] as Keyword[], // [{enabled: boolean, text: string}?],
       assigns: [] as Assign[], // [{keyword: string, type: string, set: string}?]
 
-      // The behavior or activation signal of the param trigger.
       // "Constant" (Default): set the parameter to this value.
       // "Pulse": set the parameter to this value, then reset it (0, 0.0, false) after some time.
-      behavior: 'Constant',
+      activation_signal: 'Constant',
+      pulse_delay: 0,
     },
   }),
   methods: {
@@ -381,7 +384,8 @@ export default {
         route: '/avatar/parameters/',
         keywords: [],
         assigns: [],
-        behavior: 'Constant',
+        activation_signal: 'Constant',
+        pulse_delay: 1000,
       }
 
       this.trigger_phrase = ''

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -100,7 +100,7 @@
               size="small"
               color="error"
               append-icon="mdi-delete"
-              @click.stop="deleteParam(i)"
+              @click.stop="openDeleteParamDialog(i)"
             >
               {{ $t('settings.osc.params.param.button.delete') }}
             </v-btn>
@@ -274,7 +274,7 @@
             <v-btn @click="profile_delete_dialog = false">
               {{ $t('settings.osc.params.button.cancel') }}
             </v-btn>
-            <v-btn color="primary" @click="confirmDeleteProfileDialog()">
+            <v-btn color="primary" @click="confirmDeleteProfileDialog">
               {{ $t('settings.osc.params.button.delete') }}
             </v-btn>
           </v-card-actions>
@@ -289,6 +289,26 @@
         :mode="param_dialog_mode"
         :editing-index="param_editing_index"
       />
+    </v-row>
+
+    <!-- Param Trigger Delete Dialog -->
+    <v-row justify="center">
+      <v-dialog v-model="param_delete_dialog" width="50vw">
+        <v-card>
+          <v-card-title>{{ $t('settings.osc.params.param.delete_dialog.title') }}</v-card-title>
+          <v-card-text>{{ `${param_delete_target_display}` }}</v-card-text>
+          <v-card-text>{{ $t('settings.osc.params.param.delete_dialog.text') }}</v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn @click="param_delete_dialog = false">
+              {{ $t('settings.osc.params.button.cancel') }}
+            </v-btn>
+            <v-btn color="primary" @click="confirmDeleteParamDialog">
+              {{ $t('settings.osc.params.button.delete') }}
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
     </v-row>
   </v-card>
 </template>
@@ -364,7 +384,12 @@ export default {
     
     param_dialog: false,
     param_dialog_mode: '', // "add", "edit"
+    
     param_editing_index: NaN,
+
+    param_delete_dialog: false,
+    param_delete_target: NaN,
+    param_delete_target_display: '',
   }),
   computed: {
     sortedProfiles() {
@@ -460,8 +485,20 @@ export default {
       this.param_editing_index = i
       this.param_dialog = true
     },
-    deleteParam(i: number) {
-      this.oscStore.osc_profiles[this.oscStore.current_profile].splice(i, 1)
+    openDeleteParamDialog(i: number) {
+      const current_profile_params = this.oscStore.osc_profiles[this.oscStore.current_profile]
+
+      this.param_delete_target = i
+      this.param_delete_target_display = current_profile_params[i].route
+
+      this.param_delete_dialog = true
+    },
+    confirmDeleteParamDialog() {
+      const current_profile_params = this.oscStore.osc_profiles[this.oscStore.current_profile]
+
+      current_profile_params.splice(this.param_delete_target, 1)
+
+      this.param_delete_dialog = false
     },
   },
 }

--- a/src/components/settings/OSCParams.vue
+++ b/src/components/settings/OSCParams.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card color="transparent" flat>
+  <v-card color="transparent" flat class="pb-16">
     <template v-slot:title>
       <span v-html="$t('settings.osc.params.title')"></span>
       <v-chip prepend-icon="mdi-alert-circle-outline" color="warning" class="ml-2" variant="elevated" size="small">

--- a/src/components/settings/oscparams/dialogs/ParameterTrigger.vue
+++ b/src/components/settings/oscparams/dialogs/ParameterTrigger.vue
@@ -124,7 +124,7 @@
 
         <!-- This row is displayed if the assign activation is "pulse". -->
         <v-row v-if="new_assign.activation === 'pulse'">
-          <v-col :cols="12" :lg="3">
+          <v-col :cols="12" :lg="4">
             <v-text-field
               v-if="new_assign.type !== 'bool'"
               v-model="new_assign.set1"
@@ -142,15 +142,7 @@
             />
           </v-col>
 
-          <v-spacer />
-
-          <v-col>
-            <v-icon class="h-100 align-center">mdi-arrow-right-bold</v-icon>
-          </v-col>
-
-          <v-spacer />
-
-          <v-col :cols="12" :lg="3">
+          <v-col :cols="12" :lg="4">
             <v-text-field
               v-model="new_assign.pulse_duration"
               hide-details
@@ -158,18 +150,12 @@
               type="number"
               suffix="ms"
               @input="new_assign.pulse_duration = Math.round(new_assign.pulse_duration)"
+              prepend-icon="mdi-arrow-right-bold"
+              append-icon="mdi-arrow-right-bold"
             />
           </v-col>
 
-          <v-spacer />
-
-          <v-col>
-            <v-icon class="h-100 align-center">mdi-arrow-right-bold</v-icon>
-          </v-col>
-
-          <v-spacer />
-
-          <v-col :cols="12" :lg="3">
+          <v-col :cols="12" :lg="4">
             <v-text-field
               v-if="new_assign.type !== 'bool'"
               v-model="new_assign.set2"

--- a/src/components/settings/oscparams/dialogs/ParameterTrigger.vue
+++ b/src/components/settings/oscparams/dialogs/ParameterTrigger.vue
@@ -26,13 +26,13 @@
       <v-card-text class="mt-2">
         <v-row>
           <v-col>
-            <strong v-html="$t('settings.osc.params.param.trigger_phrases')"></strong>
+            <strong v-html="$t('settings.osc.params.param.trigger_phrases')" />
             <v-chip v-if="!new_param.keywords.length" variant="text">
               {{ $t('settings.osc.params.param.empty') }}
             </v-chip>
             <v-chip
-              v-else v-model="keyword.enabled"
-              v-for="(keyword, i) in new_param.keywords"
+              v-for="(keyword, i) in new_param.keywords" v-else
+              v-model="keyword.enabled"
               class="mx-1 mb-2"
               label
               color="secondary"
@@ -61,7 +61,7 @@
       <v-card-text class="mt-2">
         <v-row>
           <v-col :cols="12">
-            <strong v-html="$t('settings.osc.params.param.assign.phrases')"></strong>
+            <strong v-html="$t('settings.osc.params.param.assign.phrases')" />
             <v-chip v-if="!new_param.assigns.length" variant="text">
               {{ $t('settings.osc.params.param.empty') }}
             </v-chip>
@@ -71,8 +71,8 @@
                 :value="assign"
                 :title="assign.keyword"
                 :subtitle="displayAssignSubtitle(assign)"
-                @click="deleteAssign(i)"
                 class="assignment-editable"
+                @click="deleteAssign(i)"
               />
             </v-list>
           </v-col>
@@ -82,7 +82,7 @@
               :items="value_types"
               hide-details
               :label="$t('settings.osc.params.param.assign.phrases_type')"
-              @update:modelValue="validateAssignValueAll"
+              @update:model-value="validateAssignValueAll"
             />
           </v-col>
           <v-col :cols="12" :lg="6">
@@ -90,13 +90,13 @@
               v-model="new_assign.activation"
               :items="[
                 { name: $t('settings.osc.params.param.assign.behavior_options.default'), value: 'default' },
-                { name: $t('settings.osc.params.param.assign.behavior_options.pulse'), value: 'pulse' }
+                { name: $t('settings.osc.params.param.assign.behavior_options.pulse'), value: 'pulse' },
               ]"
               item-title="name"
               item-value="value"
               hide-details
               :label="$t('settings.osc.params.param.assign.behavior')"
-              @update:modelValue="validateAssignValueAll"
+              @update:model-value="validateAssignValueAll"
             />
           </v-col>
         </v-row>
@@ -129,7 +129,7 @@
               v-if="new_assign.type !== 'bool'"
               v-model="new_assign.set1"
               hide-details
-              :label="$t('settings.osc.params.param.assign.phrases_value') + '1'"
+              :label="`${$t('settings.osc.params.param.assign.phrases_value')}1`"
               type="number"
               @input="validateAssignValue1"
             />
@@ -138,7 +138,7 @@
               v-model="new_assign.set1"
               :items="['true', 'false']"
               hide-details
-              :label="$t('settings.osc.params.param.assign.phrases_value') + '1'"
+              :label="`${$t('settings.osc.params.param.assign.phrases_value')}1`"
             />
           </v-col>
 
@@ -149,9 +149,9 @@
               :label="$t('settings.osc.params.param.assign.behavior_options.pulse_wait')"
               type="number"
               suffix="ms"
-              @input="new_assign.pulse_duration = Math.round(new_assign.pulse_duration)"
               prepend-icon="mdi-arrow-right-bold"
               append-icon="mdi-arrow-right-bold"
+              @input="new_assign.pulse_duration = Math.round(new_assign.pulse_duration)"
             />
           </v-col>
 
@@ -160,7 +160,7 @@
               v-if="new_assign.type !== 'bool'"
               v-model="new_assign.set2"
               hide-details
-              :label="$t('settings.osc.params.param.assign.phrases_value') + '2'"
+              :label="`${$t('settings.osc.params.param.assign.phrases_value')}2`"
               type="number"
               @input="validateAssignValue2"
             />
@@ -169,7 +169,7 @@
               v-model="new_assign.set2"
               :items="['true', 'false']"
               hide-details
-              :label="$t('settings.osc.params.param.assign.phrases_value') + '2'"
+              :label="`${$t('settings.osc.params.param.assign.phrases_value')}2`"
             />
           </v-col>
         </v-row>
@@ -269,6 +269,16 @@ export default {
       assigns: [] as Assign[], // [{keyword: string, type: string, set: string}?]
     },
   }),
+  computed: {
+    dialog: {
+      get() {
+        return this.modelValue
+      },
+      set(modelValue: boolean) {
+        this.$emit('update:modelValue', modelValue)
+      },
+    },
+  },
   watch: {
     dialog(enabled) {
       if (enabled) {
@@ -280,9 +290,9 @@ export default {
           keywords: [],
           assigns: [],
         }
-        
+
         this.trigger_phrase = ''
-        
+
         this.new_assign = {
           keyword: '',
           type: 'bool',
@@ -291,27 +301,16 @@ export default {
           activation: 'default',
           pulse_duration: 1000,
         }
-        
+
         if (this.mode === 'edit') {
           const existingParam = this.oscStore.osc_profiles[this.oscStore.current_profile][this.editingIndex as number]
           this.new_param = JSON.parse(JSON.stringify(existingParam)) // Deep copy.
         }
       }
-    }
-  },
-  computed: {
-    dialog: {
-      get() {
-        return this.modelValue
-      },
-      set(modelValue: boolean) {
-        this.$emit('update:modelValue', modelValue)
-      },
     },
   },
   methods: {
-    cancelParamDialog()
-    {
+    cancelParamDialog() {
       this.$emit('update:modelValue', false) // Close the dialog.
     },
     confirmAddParam() {
@@ -319,7 +318,7 @@ export default {
 
       this.$emit('update:modelValue', false)
     },
-    confirmEditParam() {    
+    confirmEditParam() {
       this.oscStore.osc_profiles[this.oscStore.current_profile][this.editingIndex as number] = JSON.parse(JSON.stringify(this.new_param)) // Deep copy.
 
       this.$emit('update:modelValue', false)
@@ -343,17 +342,17 @@ export default {
 
       switch (assign.type) {
         case 'int':
-          if (assign.set1 === "" || isNaN(Number(assign.set1))) // Invalid input.
-            assign.set1 = "0"
+          if (assign.set1 === '' || isNaN(Number(assign.set1))) // Invalid input.
+          { assign.set1 = '0' }
           else { // Valid input.
             // Display.
-            assign.set1 = String(parseInt(assign.set1))
+            assign.set1 = String(Number.parseInt(assign.set1))
           }
 
           break
         case 'float':
-          if (assign.set1 === "" || isNaN(Number(assign.set1))) // Invalid input.
-            assign.set1 = "0"
+          if (assign.set1 === '' || isNaN(Number(assign.set1))) // Invalid input.
+          { assign.set1 = '0' }
           else { // Valid input.
             // Display.
             assign.set1 = assign.set1.replace(/^0+(?=\d)/, '') // Remove leading zeros in front of the number.
@@ -361,8 +360,8 @@ export default {
 
           break
         case 'bool':
-          if (assign.set1 !== "true" && assign.set1 !== "false") // Invalid input.
-            assign.set1 = "true"
+          if (assign.set1 !== 'true' && assign.set1 !== 'false') // Invalid input.
+            assign.set1 = 'true'
 
           break
       }
@@ -372,17 +371,17 @@ export default {
 
       switch (assign.type) {
         case 'int':
-          if (assign.set2 === "" || isNaN(Number(assign.set2))) // Invalid input.
-            assign.set2 = "0"
+          if (assign.set2 === '' || isNaN(Number(assign.set2))) // Invalid input.
+          { assign.set2 = '0' }
           else { // Valid input.
             // Display.
-            assign.set2 = String(parseInt(assign.set2))
+            assign.set2 = String(Number.parseInt(assign.set2))
           }
 
           break
         case 'float':
-          if (assign.set2 === "" || isNaN(Number(assign.set2))) // Invalid input.
-            assign.set2 = "0"
+          if (assign.set2 === '' || isNaN(Number(assign.set2))) // Invalid input.
+          { assign.set2 = '0' }
           else { // Valid input.
             // Display.
             assign.set2 = assign.set2.replace(/^0+(?=\d)/, '') // Remove leading zeros in front of the number.
@@ -390,15 +389,15 @@ export default {
 
           break
         case 'bool':
-          if (assign.set2 !== "true" && assign.set2 !== "false") // Invalid input.
-            assign.set2 = "true"
+          if (assign.set2 !== 'true' && assign.set2 !== 'false') // Invalid input.
+            assign.set2 = 'true'
 
           break
       }
     },
     validateAssignValueAll() {
       this.validateAssignValue1()
-      
+
       if (this.new_assign.activation === 'pulse')
         this.validateAssignValue2()
     },
@@ -410,12 +409,12 @@ export default {
         return
 
       // Display.
-      if (assign.type === "float") {
+      if (assign.type === 'float') {
         if (!assign.set1.includes('.')) { // 123 → 123.0
-          assign.set1 = assign.set1 + ".0"
+          assign.set1 = `${assign.set1}.0`
         }
         else if (assign.set1.endsWith('.')) { // 123. → 123.0
-          assign.set1 = assign.set1 + "0"
+          assign.set1 = `${assign.set1}0`
         }
       }
 
@@ -439,7 +438,7 @@ export default {
       let subtitle = `set ${assign_object.type} to ${assign_object.set1}`
 
       if (assign_object.activation === 'pulse')
-        subtitle = subtitle + `, wait ${assign_object.pulse_duration}ms, set ${assign_object.type} to ${assign_object.set2}`
+        subtitle = `${subtitle}, wait ${assign_object.pulse_duration}ms, set ${assign_object.type} to ${assign_object.set2}`
 
       return subtitle
     },

--- a/src/components/settings/oscparams/dialogs/ParameterTrigger.vue
+++ b/src/components/settings/oscparams/dialogs/ParameterTrigger.vue
@@ -142,6 +142,7 @@
               hide-details
               :label="$t('settings.osc.params.param.activation_signal_options.pulse_duration')"
               type="number"
+              suffix="ms"
               @input="new_param.pulse_delay = Math.round(new_param.pulse_delay)"
             />
           </v-col>
@@ -246,9 +247,8 @@ export default {
           type: 'bool',
           set: 'true',
         }
-        console.log(this.editingIndex)
+        
         if (this.mode === 'edit') {
-          console.log('editing')
           const existingParam = this.oscStore.osc_profiles[this.oscStore.current_profile][this.editingIndex as number]
           this.new_param = JSON.parse(JSON.stringify(existingParam)) // Deep copy.
         }

--- a/src/components/settings/oscparams/dialogs/ParameterTrigger.vue
+++ b/src/components/settings/oscparams/dialogs/ParameterTrigger.vue
@@ -1,0 +1,358 @@
+<template>
+  <v-dialog v-model="dialog" width="50vw" persistent>
+    <v-card>
+      <v-card-title v-if="mode === 'add'">
+        {{ $t('settings.osc.params.param.dialog_title.add') }}
+      </v-card-title>
+      <v-card-title v-if="mode === 'edit'">
+        {{ $t('settings.osc.params.param.dialog_title.edit') }}
+      </v-card-title>
+      <v-card-text>
+        <v-row>
+          <v-col :cols="12">
+            <v-text-field v-model="new_param.route" :label="$t('settings.osc.params.param.address')" hide-details />
+          </v-col>
+          <v-col :cols="12" :md="6">
+            <v-text-field v-model="new_param.ip" label="OSC IP" hide-details />
+          </v-col>
+          <v-col>
+            <v-text-field v-model="new_param.port" label="OSC port" hide-details />
+          </v-col>
+        </v-row>
+      </v-card-text>
+
+      <v-divider class="mx-4" />
+
+      <v-card-text class="mt-2">
+        <v-row>
+          <v-col>
+            <strong v-html="$t('settings.osc.params.param.trigger_phrases')"></strong>
+            <v-chip v-if="!new_param.keywords.length" variant="text">
+              {{ $t('settings.osc.params.param.empty') }}
+            </v-chip>
+            <v-chip
+              v-else v-model="keyword.enabled"
+              v-for="(keyword, i) in new_param.keywords"
+              class="mx-1 mb-2"
+              label
+              color="secondary"
+              size="small"
+              closable
+              @click:close="deleteTrigger(i)"
+            >
+              {{ keyword.text }}
+            </v-chip>
+          </v-col>
+          <v-col :cols="12">
+            <v-text-field
+              v-model="trigger_phrase"
+              :label="$t('settings.osc.params.param.trigger_phrases_add')"
+              hide-details
+              append-icon="mdi-plus"
+              @click:append="addTrigger"
+              @keydown.enter="addTrigger"
+            />
+          </v-col>
+        </v-row>
+      </v-card-text>
+
+      <v-divider class="mx-4" />
+
+      <v-card-text class="mt-2">
+        <v-row>
+          <v-col :cols="12">
+            <strong v-html="$t('settings.osc.params.param.assign_phrases')"></strong>
+            <v-chip v-if="!new_param.assigns.length" variant="text">
+              {{ $t('settings.osc.params.param.empty') }}
+            </v-chip>
+            <v-list density="compact">
+              <v-list-item
+                v-for="(assign, i) in new_param.assigns"
+                :value="assign"
+                :title="assign.keyword"
+                :subtitle="`set ${assign.type} to ${assign.set}`"
+                @click="deleteAssign(i)"
+                class="assignment-editable"
+              />
+            </v-list>
+          </v-col>
+          <v-col :cols="12" :lg="4">
+            <v-select
+              v-model="new_assign.type"
+              :items="value_types"
+              hide-details
+              :label="$t('settings.osc.params.param.assign_phrases_type')"
+              @update:modelValue="validateAssignValue"
+            />
+          </v-col>
+          <v-col :cols="12" :lg="8">
+            <v-text-field
+              v-if="new_assign.type !== 'bool'"
+              v-model="new_assign.set"
+              hide-details
+              :label="$t('settings.osc.params.param.assign_phrases_value')"
+              type="number"
+              @input="validateAssignValue"
+            />
+            <v-select
+              v-else
+              v-model="new_assign.set"
+              :items="['true', 'false']"
+              hide-details
+              :label="$t('settings.osc.params.param.assign_phrases_value')"
+            />
+          </v-col>
+          <v-col :cols="12">
+            <v-text-field
+              v-model="new_assign.keyword"
+              :label="$t('settings.osc.params.param.assign_phrases_add')"
+              hide-details
+              append-icon="mdi-plus"
+              @click:append="addAssign"
+              @keydown.enter="addAssign"
+            />
+          </v-col>
+        </v-row>
+      </v-card-text>
+
+      <v-divider class="mx-4" />
+
+      <v-card-text class="mt-2">
+        <v-row>
+          <v-col :cols="12">
+            <strong v-html="$t('settings.osc.params.param.behavior')"></strong>
+          </v-col>
+          <v-col :cols="6">
+            <v-select
+              v-model="new_param.activation_signal"
+              :items="[
+                { name: $t('settings.osc.params.param.activation_signal_options.constant'), value: 'constant' },
+                { name: $t('settings.osc.params.param.activation_signal_options.pulse'), value: 'pulse' }
+              ]"
+              item-title="name"
+              item-value="value"
+              hide-details
+              :label="$t('settings.osc.params.param.activation_signal')"
+            />
+          </v-col>
+          <v-col :cols="6">
+            <v-text-field
+              v-if="new_param.activation_signal === 'pulse'"
+              v-model="new_param.pulse_delay"
+              hide-details
+              :label="$t('settings.osc.params.param.activation_signal_options.pulse_duration')"
+              type="number"
+              @input="new_param.pulse_delay = Math.round(new_param.pulse_delay)"
+            />
+          </v-col>
+        </v-row>
+      </v-card-text>
+
+      <v-divider class="mt-4" />
+
+      <div v-if="new_param.keywords.length && new_param.assigns.length" class="ma-2">
+        <v-list-item
+          :title="`Example phrase: 'set ${new_param.keywords[0]?.text} to ${new_param.assigns[0]?.keyword}'`"
+          :subtitle="`${new_param.route} -> ${new_param.assigns[0]?.set}`"
+        />
+      </div>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn @click="cancelParamDialog">
+          {{ $t('settings.osc.params.button.cancel') }}
+        </v-btn>
+        <v-btn v-if="mode === 'add'" color="primary" @click="confirmAddParam">
+          {{ $t('settings.osc.params.button.add') }}
+        </v-btn>
+        <v-btn v-if="mode === 'edit'" color="primary" @click="confirmEditParam">
+          {{ $t('settings.osc.params.button.confirm') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import { useOSCStore } from '@/stores/osc'
+
+interface Keyword {
+  enabled: boolean
+  text: string
+}
+interface Assign {
+  keyword: string
+  type: string
+  set: string // Receive user-input as a string. Parse it when finally sending a payload.
+}
+
+export default {
+  name: 'SettingsGeneral',
+  props: {
+    modelValue: Boolean,
+    mode: String,
+    editingIndex: Number,
+  },
+  emits: ['update:modelValue'],
+  setup() {
+    const oscStore = useOSCStore()
+
+    return {
+      oscStore,
+    }
+  },
+  data: () => ({
+    trigger_phrase: '',
+
+    value_types: ['bool', 'int', 'float'],
+
+    new_assign: {
+      keyword: '',
+      type: 'bool',
+      set: 'true',
+    },
+
+    new_param: {
+      // name: '',
+      ip: '',
+      port: '',
+      route: '/avatar/parameters/',
+      keywords: [] as Keyword[], // [{enabled: boolean, text: string}?],
+      assigns: [] as Assign[], // [{keyword: string, type: string, set: string}?]
+
+      // "constant" (Default): set the parameter to this value.
+      // "pulse": set the parameter to this value, then reset it (0, 0.0, false) after some time.
+      activation_signal: 'constant',
+      pulse_delay: 0,
+    },
+  }),
+  watch: {
+    dialog(enabled) {
+      if (enabled) {
+        // Reset the dialog's fields.
+        this.new_param = {
+          ip: this.oscStore.ip,
+          port: this.oscStore.port,
+          route: '/avatar/parameters/',
+          keywords: [],
+          assigns: [],
+          activation_signal: 'constant',
+          pulse_delay: 1000,
+        }
+
+        this.trigger_phrase = ''
+
+        this.new_assign = {
+          keyword: '',
+          type: 'bool',
+          set: 'true',
+        }
+        console.log(this.editingIndex)
+        if (this.mode === 'edit') {
+          console.log('editing')
+          const existingParam = this.oscStore.osc_profiles[this.oscStore.current_profile][this.editingIndex as number]
+          this.new_param = JSON.parse(JSON.stringify(existingParam)) // Deep copy.
+        }
+      }
+    }
+  },
+  computed: {
+    dialog: {
+      get() {
+        return this.modelValue
+      },
+      set(modelValue: boolean) {
+        this.$emit('update:modelValue', modelValue)
+      },
+    },
+  },
+  methods: {
+    cancelParamDialog()
+    {
+      this.$emit('update:modelValue', false) // Close the dialog.
+    },
+    confirmAddParam() {
+      this.oscStore.osc_profiles[this.oscStore.current_profile].push(this.new_param)
+
+      this.$emit('update:modelValue', false)
+    },
+    confirmEditParam() {    
+      this.oscStore.osc_profiles[this.oscStore.current_profile][this.editingIndex as number] = JSON.parse(JSON.stringify(this.new_param)) // Deep copy.
+
+      this.$emit('update:modelValue', false)
+    },
+    deleteParam(i: number) {
+      this.oscStore.osc_profiles[this.oscStore.current_profile].splice(i, 1)
+    },
+    addTrigger() {
+      if (!this.trigger_phrase.trim()) // The trigger phrase field is empty.
+        return
+
+      this.new_param.keywords.push({ enabled: true, text: this.trigger_phrase })
+
+      this.trigger_phrase = ''
+    },
+    deleteTrigger(i: number) {
+      this.new_param.keywords.splice(i, 1)
+    },
+    validateAssignValue() {
+      const assign = this.new_assign
+
+      switch (assign.type) {
+        case 'int':
+          if (assign.set === "" || isNaN(Number(assign.set))) // Invalid input.
+            assign.set = "0"
+          else { // Valid input.
+            // Display.
+            assign.set = String(parseInt(assign.set))
+          }
+
+          break
+        case 'float':
+          if (assign.set === "" || isNaN(Number(assign.set))) // Invalid input.
+            assign.set = "0"
+          else { // Valid input.
+            // Display.
+            assign.set = assign.set.replace(/^0+(?=\d)/, '') // Remove leading zeros in front of the number.
+          }
+
+          break
+        case 'bool':
+          if (assign.set !== "true" && assign.set !== "false") // Invalid input.
+            assign.set = "true"
+
+          break
+      }
+    },
+    addAssign() {
+      const assign = this.new_assign
+
+      // Validation.
+      if (!assign.keyword.trim()) // The assign keyword field is empty.
+        return
+
+      // Display.
+      if (assign.type === "float") {
+        if (!assign.set.includes('.')) { // 123 → 123.0
+          assign.set = assign.set + ".0"
+        }
+        else if (assign.set.endsWith('.')) { // 123. → 123.0
+          assign.set = assign.set + "0"
+        }
+      }
+
+      // Store.
+      this.new_param.assigns.push(assign)
+
+      // Partially reset the assign fields.
+      this.new_assign = {
+        keyword: '',
+        type: assign.type,
+        set: assign.set,
+      }
+    },
+    deleteAssign(i: number) {
+      this.new_param.assigns.splice(i, 1)
+    },
+  },
+}
+</script>

--- a/src/components/settings/oscparams/dialogs/ParameterTrigger.vue
+++ b/src/components/settings/oscparams/dialogs/ParameterTrigger.vue
@@ -61,7 +61,7 @@
       <v-card-text class="mt-2">
         <v-row>
           <v-col :cols="12">
-            <strong v-html="$t('settings.osc.params.param.assign_phrases')"></strong>
+            <strong v-html="$t('settings.osc.params.param.assign.phrases')"></strong>
             <v-chip v-if="!new_param.assigns.length" variant="text">
               {{ $t('settings.osc.params.param.empty') }}
             </v-chip>
@@ -70,80 +70,133 @@
                 v-for="(assign, i) in new_param.assigns"
                 :value="assign"
                 :title="assign.keyword"
-                :subtitle="`set ${assign.type} to ${assign.set}`"
+                :subtitle="displayAssignSubtitle(assign)"
                 @click="deleteAssign(i)"
                 class="assignment-editable"
               />
             </v-list>
           </v-col>
-          <v-col :cols="12" :lg="4">
+          <v-col :cols="12" :lg="6">
             <v-select
               v-model="new_assign.type"
               :items="value_types"
               hide-details
-              :label="$t('settings.osc.params.param.assign_phrases_type')"
-              @update:modelValue="validateAssignValue"
+              :label="$t('settings.osc.params.param.assign.phrases_type')"
+              @update:modelValue="validateAssignValueAll"
             />
           </v-col>
-          <v-col :cols="12" :lg="8">
-            <v-text-field
-              v-if="new_assign.type !== 'bool'"
-              v-model="new_assign.set"
-              hide-details
-              :label="$t('settings.osc.params.param.assign_phrases_value')"
-              type="number"
-              @input="validateAssignValue"
-            />
+          <v-col :cols="12" :lg="6">
             <v-select
-              v-else
-              v-model="new_assign.set"
-              :items="['true', 'false']"
-              hide-details
-              :label="$t('settings.osc.params.param.assign_phrases_value')"
-            />
-          </v-col>
-          <v-col :cols="12">
-            <v-text-field
-              v-model="new_assign.keyword"
-              :label="$t('settings.osc.params.param.assign_phrases_add')"
-              hide-details
-              append-icon="mdi-plus"
-              @click:append="addAssign"
-              @keydown.enter="addAssign"
-            />
-          </v-col>
-        </v-row>
-      </v-card-text>
-
-      <v-divider class="mx-4" />
-
-      <v-card-text class="mt-2">
-        <v-row>
-          <v-col :cols="12">
-            <strong v-html="$t('settings.osc.params.param.behavior')"></strong>
-          </v-col>
-          <v-col :cols="6">
-            <v-select
-              v-model="new_param.activation_signal"
+              v-model="new_assign.activation"
               :items="[
-                { name: $t('settings.osc.params.param.activation_signal_options.constant'), value: 'constant' },
-                { name: $t('settings.osc.params.param.activation_signal_options.pulse'), value: 'pulse' }
+                { name: $t('settings.osc.params.param.assign.behavior_options.default'), value: 'default' },
+                { name: $t('settings.osc.params.param.assign.behavior_options.pulse'), value: 'pulse' }
               ]"
               item-title="name"
               item-value="value"
               hide-details
-              :label="$t('settings.osc.params.param.activation_signal')"
+              :label="$t('settings.osc.params.param.assign.behavior')"
+              @update:modelValue="validateAssignValueAll"
             />
           </v-col>
-          <v-col :cols="6">
+        </v-row>
+
+        <!-- This row is displayed if the assign activation is "default". -->
+        <v-row v-if="new_assign.activation === 'default'">
+          <v-col :cols="12" :lg="6">
             <v-text-field
-              v-if="new_param.activation_signal === 'pulse'"
-              v-model="new_param.pulse_delay"
+              v-if="new_assign.type !== 'bool'"
+              v-model="new_assign.set1"
               hide-details
-              :label="$t('settings.osc.params.param.activation_signal_options.pulse_duration')"
+              :label="$t('settings.osc.params.param.assign.phrases_value')"
+              type="number"
+              @input="validateAssignValue1"
+            />
+            <v-select
+              v-else
+              v-model="new_assign.set1"
+              :items="['true', 'false']"
+              hide-details
+              :label="$t('settings.osc.params.param.assign.phrases_value')"
+            />
+          </v-col>
+        </v-row>
+
+        <!-- This row is displayed if the assign activation is "pulse". -->
+        <v-row v-if="new_assign.activation === 'pulse'">
+          <v-col :cols="12" :lg="3">
+            <v-text-field
+              v-if="new_assign.type !== 'bool'"
+              v-model="new_assign.set1"
+              hide-details
+              :label="$t('settings.osc.params.param.assign.phrases_value') + '1'"
+              type="number"
+              @input="validateAssignValue1"
+            />
+            <v-select
+              v-else
+              v-model="new_assign.set1"
+              :items="['true', 'false']"
+              hide-details
+              :label="$t('settings.osc.params.param.assign.phrases_value') + '1'"
+            />
+          </v-col>
+
+          <v-spacer />
+
+          <v-col>
+            <v-icon class="h-100 align-center">mdi-arrow-right-bold</v-icon>
+          </v-col>
+
+          <v-spacer />
+
+          <v-col :cols="12" :lg="3">
+            <v-text-field
+              v-model="new_assign.pulse_duration"
+              hide-details
+              :label="$t('settings.osc.params.param.assign.behavior_options.pulse_wait')"
               type="number"
               suffix="ms"
-              @input="new_param.pulse_delay = Math.round(new_param.pulse_delay)"
+              @input="new_assign.pulse_duration = Math.round(new_assign.pulse_duration)"
+            />
+          </v-col>
+
+          <v-spacer />
+
+          <v-col>
+            <v-icon class="h-100 align-center">mdi-arrow-right-bold</v-icon>
+          </v-col>
+
+          <v-spacer />
+
+          <v-col :cols="12" :lg="3">
+            <v-text-field
+              v-if="new_assign.type !== 'bool'"
+              v-model="new_assign.set2"
+              hide-details
+              :label="$t('settings.osc.params.param.assign.phrases_value') + '2'"
+              type="number"
+              @input="validateAssignValue2"
+            />
+            <v-select
+              v-else
+              v-model="new_assign.set2"
+              :items="['true', 'false']"
+              hide-details
+              :label="$t('settings.osc.params.param.assign.phrases_value') + '2'"
+            />
+          </v-col>
+        </v-row>
+
+        <v-row>
+          <v-col :cols="12">
+            <v-text-field
+              v-model="new_assign.keyword"
+              :label="$t('settings.osc.params.param.assign.phrases_add')"
+              hide-details
+              append-icon="mdi-plus"
+              @click:append="addAssign"
+              @keydown.enter="addAssign"
             />
           </v-col>
         </v-row>
@@ -154,7 +207,7 @@
       <div v-if="new_param.keywords.length && new_param.assigns.length" class="ma-2">
         <v-list-item
           :title="`Example phrase: 'set ${new_param.keywords[0]?.text} to ${new_param.assigns[0]?.keyword}'`"
-          :subtitle="`${new_param.route} -> ${new_param.assigns[0]?.set}`"
+          :subtitle="`${new_param.route} -> ${new_param.assigns[0]?.set1}`"
         />
       </div>
       <v-card-actions>
@@ -183,7 +236,10 @@ interface Keyword {
 interface Assign {
   keyword: string
   type: string
-  set: string // Receive user-input as a string. Parse it when finally sending a payload.
+  set1: string // Receive user-input as a string. Parse it when finally sending a payload.
+  set2: string
+  activation: string
+  pulse_duration: number
 }
 
 export default {
@@ -209,7 +265,13 @@ export default {
     new_assign: {
       keyword: '',
       type: 'bool',
-      set: 'true',
+      set1: 'true',
+      set2: 'false',
+
+      // "default": set the parameter to a value.
+      // "pulse": set the parameter to a value, wait some time, then set the parameter to another value.
+      activation: 'default',
+      pulse_duration: 0,
     },
 
     new_param: {
@@ -219,11 +281,6 @@ export default {
       route: '/avatar/parameters/',
       keywords: [] as Keyword[], // [{enabled: boolean, text: string}?],
       assigns: [] as Assign[], // [{keyword: string, type: string, set: string}?]
-
-      // "constant" (Default): set the parameter to this value.
-      // "pulse": set the parameter to this value, then reset it (0, 0.0, false) after some time.
-      activation_signal: 'constant',
-      pulse_delay: 0,
     },
   }),
   watch: {
@@ -236,16 +293,17 @@ export default {
           route: '/avatar/parameters/',
           keywords: [],
           assigns: [],
-          activation_signal: 'constant',
-          pulse_delay: 1000,
         }
-
+        
         this.trigger_phrase = ''
-
+        
         this.new_assign = {
           keyword: '',
           type: 'bool',
-          set: 'true',
+          set1: 'true',
+          set2: 'false',
+          activation: 'default',
+          pulse_duration: 1000,
         }
         
         if (this.mode === 'edit') {
@@ -294,34 +352,69 @@ export default {
     deleteTrigger(i: number) {
       this.new_param.keywords.splice(i, 1)
     },
-    validateAssignValue() {
+    validateAssignValue1() {
       const assign = this.new_assign
 
       switch (assign.type) {
         case 'int':
-          if (assign.set === "" || isNaN(Number(assign.set))) // Invalid input.
-            assign.set = "0"
+          if (assign.set1 === "" || isNaN(Number(assign.set1))) // Invalid input.
+            assign.set1 = "0"
           else { // Valid input.
             // Display.
-            assign.set = String(parseInt(assign.set))
+            assign.set1 = String(parseInt(assign.set1))
           }
 
           break
         case 'float':
-          if (assign.set === "" || isNaN(Number(assign.set))) // Invalid input.
-            assign.set = "0"
+          if (assign.set1 === "" || isNaN(Number(assign.set1))) // Invalid input.
+            assign.set1 = "0"
           else { // Valid input.
             // Display.
-            assign.set = assign.set.replace(/^0+(?=\d)/, '') // Remove leading zeros in front of the number.
+            assign.set1 = assign.set1.replace(/^0+(?=\d)/, '') // Remove leading zeros in front of the number.
           }
 
           break
         case 'bool':
-          if (assign.set !== "true" && assign.set !== "false") // Invalid input.
-            assign.set = "true"
+          if (assign.set1 !== "true" && assign.set1 !== "false") // Invalid input.
+            assign.set1 = "true"
 
           break
       }
+    },
+    validateAssignValue2() {
+      const assign = this.new_assign
+
+      switch (assign.type) {
+        case 'int':
+          if (assign.set2 === "" || isNaN(Number(assign.set2))) // Invalid input.
+            assign.set2 = "0"
+          else { // Valid input.
+            // Display.
+            assign.set2 = String(parseInt(assign.set2))
+          }
+
+          break
+        case 'float':
+          if (assign.set2 === "" || isNaN(Number(assign.set2))) // Invalid input.
+            assign.set2 = "0"
+          else { // Valid input.
+            // Display.
+            assign.set2 = assign.set2.replace(/^0+(?=\d)/, '') // Remove leading zeros in front of the number.
+          }
+
+          break
+        case 'bool':
+          if (assign.set2 !== "true" && assign.set2 !== "false") // Invalid input.
+            assign.set2 = "true"
+
+          break
+      }
+    },
+    validateAssignValueAll() {
+      this.validateAssignValue1()
+      
+      if (this.new_assign.activation === 'pulse')
+        this.validateAssignValue2()
     },
     addAssign() {
       const assign = this.new_assign
@@ -332,11 +425,11 @@ export default {
 
       // Display.
       if (assign.type === "float") {
-        if (!assign.set.includes('.')) { // 123 → 123.0
-          assign.set = assign.set + ".0"
+        if (!assign.set1.includes('.')) { // 123 → 123.0
+          assign.set1 = assign.set1 + ".0"
         }
-        else if (assign.set.endsWith('.')) { // 123. → 123.0
-          assign.set = assign.set + "0"
+        else if (assign.set1.endsWith('.')) { // 123. → 123.0
+          assign.set1 = assign.set1 + "0"
         }
       }
 
@@ -347,11 +440,22 @@ export default {
       this.new_assign = {
         keyword: '',
         type: assign.type,
-        set: assign.set,
+        set1: assign.set1,
+        set2: 'false',
+        activation: 'default',
+        pulse_duration: 1000,
       }
     },
     deleteAssign(i: number) {
       this.new_param.assigns.splice(i, 1)
+    },
+    displayAssignSubtitle(assign_object: any) {
+      let subtitle = `set ${assign_object.type} to ${assign_object.set1}`
+
+      if (assign_object.activation === 'pulse')
+        subtitle = subtitle + `, wait ${assign_object.pulse_duration}ms, set ${assign_object.type} to ${assign_object.set2}`
+
+      return subtitle
     },
   },
 }

--- a/src/plugins/localization/en.ts
+++ b/src/plugins/localization/en.ts
@@ -231,6 +231,10 @@ export default {
               pulse_wait: 'Wait'
             },
           },
+          delete_dialog: {
+            title: 'Delete parameter',
+            text: 'Are you sure that you want to delete this parameter?',
+          },
         },
         empty: 'Use the + button to add a new custom parameter trigger!',
       },

--- a/src/plugins/localization/en.ts
+++ b/src/plugins/localization/en.ts
@@ -18,6 +18,7 @@ export default {
     type_message: 'Type a message',
     beta: 'BETA',
     update: 'Update',
+    subject_to_change: 'Subject to change',
   },
   alerts: {
     no_speech: 'Your browser does not support Web Speech API (Speech-to-text).',

--- a/src/plugins/localization/en.ts
+++ b/src/plugins/localization/en.ts
@@ -191,7 +191,7 @@ export default {
           cancel: 'CANCEL',
           confirm: 'CONFIRM',
           add: 'ADD',
-          delete: 'DELETE'
+          delete: 'DELETE',
         },
         profile: {
           label: 'Select a profile',
@@ -210,26 +210,26 @@ export default {
         param: {
           button: {
             edit: 'EDIT',
-            delete: 'DELETE'
+            delete: 'DELETE',
           },
           dialog_title: {
             add: 'Add parameter trigger',
             edit: 'Edit parameter trigger',
           },
-          address: "Parameter address",
+          address: 'Parameter address',
           empty: 'none :c',
           trigger_phrases: 'Trigger phrases:',
           trigger_phrases_add: 'Add trigger word/phrase',
           assign: {
             phrases: 'Assign phrases:',
-            phrases_type: "Value type",
+            phrases_type: 'Value type',
             phrases_value: 'Value ', // This leading space is for displaying "Value 1" and "Value 2".
             phrases_add: 'Add assign word/phrase (e.g., on)',
             behavior: 'Behavior',
             behavior_options: {
               default: 'Default',
               pulse: 'Pulse',
-              pulse_wait: 'Wait'
+              pulse_wait: 'Wait',
             },
           },
           delete_dialog: {

--- a/src/plugins/localization/en.ts
+++ b/src/plugins/localization/en.ts
@@ -192,12 +192,19 @@ export default {
           add: 'ADD',
           delete: 'DELETE'
         },
-        menu: {
-          profile: 'Select a profile',
-          profile_add: 'Add new profile',
-          profile_add_label: 'Profile name',
-          profile_delete: 'Delete profile',
-          profile_delete_text: 'Are you sure that you want to delete this profile?',
+        profile: {
+          label: 'Select a profile',
+          dialog: {
+            title: {
+              add: 'Add new profile',
+              edit: 'Rename profile',
+            },
+            field_label: 'Profile name',
+          },
+          delete_dialog: {
+            title: 'Delete profile',
+            text: 'Are you sure that you want to delete this profile?',
+          },
         },
         param: {
           button: {
@@ -205,8 +212,8 @@ export default {
             delete: 'DELETE'
           },
           dialog_title: {
-            adding: 'Add parameter trigger',
-            editing: 'Edit parameter trigger',
+            add: 'Add parameter trigger',
+            edit: 'Edit parameter trigger',
           },
           address: "Parameter address",
           empty: 'none :c',

--- a/src/plugins/localization/en.ts
+++ b/src/plugins/localization/en.ts
@@ -219,16 +219,17 @@ export default {
           empty: 'none :c',
           trigger_phrases: 'Trigger phrases:',
           trigger_phrases_add: 'Add trigger word/phrase',
-          assign_phrases: 'Assign phrases:',
-          assign_phrases_type: "Value type",
-          assign_phrases_value: 'Value',
-          assign_phrases_add: 'Add assign word/phrase (e.g., on)',
-          behavior: 'Behavior:',
-          activation_signal: 'Activation signal',
-          activation_signal_options: {
-            constant: 'Constant',
-            pulse: 'Pulse',
-            pulse_duration: 'Pulse duration (milliseconds)'
+          assign: {
+            phrases: 'Assign phrases:',
+            phrases_type: "Value type",
+            phrases_value: 'Value ', // This leading space is for displaying "Value 1" and "Value 2".
+            phrases_add: 'Add assign word/phrase (e.g., on)',
+            behavior: 'Behavior',
+            behavior_options: {
+              default: 'Default',
+              pulse: 'Pulse',
+              pulse_wait: 'Wait'
+            },
           },
         },
         empty: 'Use the + button to add a new custom parameter trigger!',

--- a/src/plugins/localization/en.ts
+++ b/src/plugins/localization/en.ts
@@ -170,8 +170,8 @@ export default {
       general: {
         title: 'General',
         description: 'Settings for customizing OSC connection',
-        osc_ip: 'Default OSC IP',
-        osc_port: 'Default OSC Port',
+        osc_ip: 'OSC IP',
+        osc_port: 'OSC Port',
         enabled: 'Send all text with OSC (when broadcasting)',
         typing_indicator: 'Enable typing indicator when typing',
         speech_indicator: 'Enable typing indicator for speech-to-text',
@@ -184,7 +184,47 @@ export default {
         },
       },
       params: {
-        title: 'Custom Params',
+        title: 'Parameter Triggers',
+        description: 'Add parameter triggers',
+        button: {
+          cancel: 'CANCEL',
+          confirm: 'CONFIRM',
+          add: 'ADD',
+          delete: 'DELETE'
+        },
+        menu: {
+          profile: 'Select a profile',
+          profile_add: 'Add new profile',
+          profile_add_label: 'Profile name',
+          profile_delete: 'Delete profile',
+          profile_delete_text: 'Are you sure that you want to delete this profile?',
+        },
+        param: {
+          button: {
+            edit: 'EDIT',
+            delete: 'DELETE'
+          },
+          dialog_title: {
+            adding: 'Add parameter trigger',
+            editing: 'Edit parameter trigger',
+          },
+          address: "Parameter address",
+          empty: 'none :c',
+          trigger_phrases: 'Trigger phrases:',
+          trigger_phrases_add: 'Add trigger word/phrase',
+          assign_phrases: 'Assign phrases:',
+          assign_phrases_type: "Value type",
+          assign_phrases_value: 'Value',
+          assign_phrases_add: 'Add assign word/phrase (e.g., on)',
+          behavior: 'Behavior:',
+          activation_signal: 'Activation signal',
+          activation_signal_options: {
+            constant: 'Constant',
+            pulse: 'Pulse',
+            pulse_duration: 'Pulse duration (milliseconds)'
+          },
+        },
+        empty: 'Use the + button to add a new custom parameter trigger!',
       },
     },
   },

--- a/src/plugins/localization/ja.ts
+++ b/src/plugins/localization/ja.ts
@@ -219,16 +219,17 @@ export default {
           empty: '無し (；ω；)',
           trigger_phrases: 'トリガーフレーズ：',
           trigger_phrases_add: 'トリガーフレーズを追加',
-          assign_phrases: '代入フレーズ：',
-          assign_phrases_type: '型',
-          assign_phrases_value: '値',
-          assign_phrases_add: '代入フレーズを追加',
-          behavior: '挙動：',
-          activation_signal: 'アクティベーション信号',
-          activation_signal_options: {
-              constant: '定数',
-              pulse: 'パルス',
-              pulse_duration: 'パルス幅'
+          assign: {
+            phrases: '代入フレーズ：',
+            phrases_type: '型',
+            phrases_value: '値',
+            phrases_add: '代入フレーズを追加',
+            behavior: '挙動',
+            behavior_options: {
+                default: 'デフォルト',
+                pulse: 'パルス',
+                pulse_wait: '待機時間'
+            },
           },
         },
         empty: 'カスタムパラメータトリガーを追加するには＋ボタンを使用してください！',

--- a/src/plugins/localization/ja.ts
+++ b/src/plugins/localization/ja.ts
@@ -170,8 +170,8 @@ export default {
       general: {
         title: 'OSC設定',
         description: 'OSC接続の設定',
-        osc_ip: 'デフォルトのOSC IP',
-        osc_port: 'デフォルトのOSC Port',
+        osc_ip: 'OSC IP',
+        osc_port: 'OSC Port',
         enabled: 'OSCで全文送信（ブロードキャスト中）',
         typing_indicator: 'タイピング時にタイピングインジケーターを有効',
         speech_indicator: 'Speech-to-text時のタイピングインジケーターを有効',
@@ -184,7 +184,47 @@ export default {
         },
       },
       params: {
-        title: 'カスタムパラメータ',
+        title: 'パラメータトリガー',
+        description: 'カスタムパラメータトリガーを追加',
+        button: {
+          cancel: 'キャンセル',
+          confirm: 'OK',
+          add: '追加',
+          delete: '削除',
+        },
+        menu: {
+          profile: 'プロファイル選択',
+          profile_add: 'プロファイルを追加',
+          profile_add_label: 'プロファイル名',
+          profile_delete: 'プロファイルを削除',
+          profile_delete_text: 'このプロファイルを削除してもよろしいですか？',
+        },
+        param: {
+          button: {
+            edit: '編集',
+            delete: '削除'
+          },
+          dialog_title: {
+            adding: 'パラメータトリガーを追加',
+            editing: 'パラメータトリガーを編集',
+          },
+          address: "パラメーターアドレス",
+          empty: '無し (；ω；)',
+          trigger_phrases: 'トリガーフレーズ：',
+          trigger_phrases_add: 'トリガーフレーズを追加',
+          assign_phrases: '代入フレーズ：',
+          assign_phrases_type: '型',
+          assign_phrases_value: '値',
+          assign_phrases_add: '代入フレーズを追加',
+          behavior: '挙動：',
+          activation_signal: 'アクティベーション信号',
+          activation_signal_options: {
+              constant: '定数',
+              pulse: 'パルス',
+              pulse_duration: 'パルス幅'
+          },
+        },
+        empty: 'カスタムパラメータトリガーを追加するには＋ボタンを使用してください！',
       },
     },
   },

--- a/src/plugins/localization/ja.ts
+++ b/src/plugins/localization/ja.ts
@@ -192,12 +192,19 @@ export default {
           add: '追加',
           delete: '削除',
         },
-        menu: {
-          profile: 'プロファイル選択',
-          profile_add: 'プロファイルを追加',
-          profile_add_label: 'プロファイル名',
-          profile_delete: 'プロファイルを削除',
-          profile_delete_text: 'このプロファイルを削除してもよろしいですか？',
+        profile: {
+          label: 'プロファイル選択',
+          dialog: {
+            title: {
+              add: 'プロファイルを追加',
+              edit: 'プロファイル名を変更',
+            },
+            field_label: 'プロファイル名',
+          },
+          delete_dialog: {
+            title: 'プロファイルを削除',
+            text: 'このプロファイルを削除してもよろしいですか？',
+          },
         },
         param: {
           button: {
@@ -205,8 +212,8 @@ export default {
             delete: '削除'
           },
           dialog_title: {
-            adding: 'パラメータトリガーを追加',
-            editing: 'パラメータトリガーを編集',
+            add: 'パラメータトリガーを追加',
+            edit: 'パラメータトリガーを編集',
           },
           address: "パラメーターアドレス",
           empty: '無し (；ω；)',

--- a/src/plugins/localization/ja.ts
+++ b/src/plugins/localization/ja.ts
@@ -18,6 +18,7 @@ export default {
     type_message: 'メッセージを送信',
     beta: 'ベータ',
     update: 'アップデート',
+    subject_to_change: '変更の可能性があります',
   },
   alerts: {
     no_speech: 'このブラウザはWeb Speech APIをサポートしていません（Speech-to-text）',

--- a/src/plugins/localization/ja.ts
+++ b/src/plugins/localization/ja.ts
@@ -215,7 +215,7 @@ export default {
             add: 'パラメータトリガーを追加',
             edit: 'パラメータトリガーを編集',
           },
-          address: "パラメーターアドレス",
+          address: "パラメータアドレス",
           empty: '無し (；ω；)',
           trigger_phrases: 'トリガーフレーズ：',
           trigger_phrases_add: 'トリガーフレーズを追加',
@@ -230,6 +230,10 @@ export default {
                 pulse: 'パルス',
                 pulse_wait: '待機時間'
             },
+          },
+          delete_dialog: {
+            title: 'パラメータを削除',
+            text: 'このパラメータを削除してもよろしいですか？',
           },
         },
         empty: 'カスタムパラメータトリガーを追加するには＋ボタンを使用してください！',

--- a/src/plugins/localization/ja.ts
+++ b/src/plugins/localization/ja.ts
@@ -210,13 +210,13 @@ export default {
         param: {
           button: {
             edit: '編集',
-            delete: '削除'
+            delete: '削除',
           },
           dialog_title: {
             add: 'パラメータトリガーを追加',
             edit: 'パラメータトリガーを編集',
           },
-          address: "パラメータアドレス",
+          address: 'パラメータアドレス',
           empty: '無し (；ω；)',
           trigger_phrases: 'トリガーフレーズ：',
           trigger_phrases_add: 'トリガーフレーズを追加',
@@ -227,9 +227,9 @@ export default {
             phrases_add: '代入フレーズを追加',
             behavior: '挙動',
             behavior_options: {
-                default: 'デフォルト',
-                pulse: 'パルス',
-                pulse_wait: '待機時間'
+              default: 'デフォルト',
+              pulse: 'パルス',
+              pulse_wait: '待機時間',
             },
           },
           delete_dialog: {

--- a/src/stores/osc.ts
+++ b/src/stores/osc.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 
 interface Profile {
-  [name: string]: Param[];
+  [name: string]: Param[]
 }
 interface Param {
   ip: string
@@ -39,10 +39,10 @@ export const useOSCStore = defineStore('osc', {
     show_keyboard: false,
 
     osc_profiles: {
-      'Default': []
+      Default: [],
     } as Profile,
 
-    current_profile: 'Default'
+    current_profile: 'Default',
   }),
   getters: {
 

--- a/src/stores/osc.ts
+++ b/src/stores/osc.ts
@@ -9,8 +9,6 @@ interface Param {
   route: string
   keywords: Keyword[]
   assigns: Assign[]
-  activation_signal: string
-  pulse_delay: number
 }
 interface Keyword {
   enabled: boolean
@@ -19,7 +17,10 @@ interface Keyword {
 interface Assign {
   keyword: string
   type: string
-  set: string
+  set1: string
+  set2: string
+  activation: string
+  pulse_duration: number
 }
 
 export const useOSCStore = defineStore('osc', {

--- a/src/stores/osc.ts
+++ b/src/stores/osc.ts
@@ -3,14 +3,14 @@ import { defineStore } from 'pinia'
 interface Profile {
   [name: string]: Param[];
 }
-
 interface Param {
   ip: string
   port: string
   route: string
   keywords: Keyword[]
   assigns: Assign[]
-  behavior: string
+  activation_signal: string
+  pulse_delay: number
 }
 interface Keyword {
   enabled: boolean

--- a/src/stores/osc.ts
+++ b/src/stores/osc.ts
@@ -14,7 +14,7 @@ interface Keyword {
 interface Assign {
   keyword: string
   type: string
-  set: boolean | number | string
+  set: string
 }
 
 export const useOSCStore = defineStore('osc', {

--- a/src/stores/osc.ts
+++ b/src/stores/osc.ts
@@ -6,6 +6,7 @@ interface Param {
   route: string
   keywords: Keyword[]
   assigns: Assign[]
+  behavior: string
 }
 interface Keyword {
   enabled: boolean

--- a/src/stores/osc.ts
+++ b/src/stores/osc.ts
@@ -1,5 +1,9 @@
 import { defineStore } from 'pinia'
 
+interface Profile {
+  [name: string]: Param[];
+}
+
 interface Param {
   ip: string
   port: string
@@ -33,7 +37,11 @@ export const useOSCStore = defineStore('osc', {
     sfx: true, // vrchat sfx indicator
     show_keyboard: false,
 
-    osc_params: [] as Param[],
+    osc_profiles: {
+      'Default': []
+    } as Profile,
+
+    current_profile: 'Default'
   }),
   getters: {
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description <!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This is a collection of changes to the OSCParams component and related components.

---

#### Fix values sent via OSC being evaluated as 0 by VRChat

Problem: Incorrectly typed data would be sent to VRChat, and parameters would not be correctly driven.

Solution: Payloads are now validated and parsed before being sent to VRChat.

I don't how this will affect other applications, if the OSC implementation is intended to be used with applications besides VRChat.

---

#### Implement editing

Editing is now implemented and enabled for _param triggers_.

<table>
    <tr>
        <td align="center">
            A basic view of <i>Custom Params</i>.
        </td>
        <td align="center">
            <i>Edit</i> was clicked.
        </td>
    </tr>
    <tr>
        <td align="center">
            <img src="https://github.com/naeruru/mimiuchi/assets/117558001/be88e6f0-7f19-487e-80da-87f1e11d01e1" width="98%" />
        </td>
        <td align="center">
            <img src="https://github.com/naeruru/mimiuchi/assets/117558001/613944ae-6c0e-4514-a9bf-5de6414960e9" width="98%" />
        </td>
    </tr>
</table>

Additionally, the removal of _assign phrases_ is now implemented.

<table>
    <tr>
        <td align="center">
            A mouseover on an <i>assign phrase</i>.
        </td>
        <td align="center">
            The <i>assign phrase</i> was clicked and deleted.
        </td>
    </tr>
    <tr>
        <td align="center">
            <img src="https://github.com/naeruru/mimiuchi/assets/117558001/bc1f4b2e-6165-4abd-8fb0-e6af2f104314" width="98%" />
        </td>
        <td align="center">
            <img src="https://github.com/naeruru/mimiuchi/assets/117558001/47b6efa8-03f2-40d8-a167-291067af07d5" width="98%" />
        </td>
    </tr>
</table>

Changed behaviors:
- The _Add custom param trigger_ dialogue will always open with default values and/or empty input fields.
  - Any leftover input will be lost upon canceling or closing the dialog.
- _Assign phrases_
  - When the field "Value type" is changed, the currently existing value in the field "Value" will be validated.
    - This provides default values for the field "Value" and initializes it with input.
    - This handles unregulated input and resets the field "Value" to a default value if it doesn't correspond to the type.
      - This solves a problem wherein noncorresponding input would remain despite "Value type" being changed (e.g., "Value type" of "bool" and "Value" of "123").
    - If the existing value is valid, it can be reused.
      - Example: an inputted number for "int" will not be reset and can be reused if the user has chosen "float".
      - Example: an inputted number for "float" will not be reset and can be parsed as an int if the user has chosen "int".
      - This makes the workflow for editing quicker and more convenient.
  - The field "Value" is constantly validated on user-input.
  - When the user attempts to add an _assign phrase_ with missing input, the action will be blocked.
  - When the user successfully adds an _assign phrase_, the fields will only be partially reset.
    - Only the field "Add assign word/phrase" (i.e., keyword) will be reset.
    - This allows users to quickly add multiple _assign phrases_ with similar settings without having to reselect the "Value type" and "Value".

---

#### Standardize the design of the component title to match other components

<table>
    <tr>
        <td>
            Before
        </td>
        <td>
            After
        </td>
    </tr>
    <tr>
        <td>
            <img src="https://github.com/naeruru/mimiuchi/assets/117558001/cf76251b-ca5b-4cc9-a0b0-38b2e87cc5d1" />
        </td>
        <td>
            <img src="https://github.com/naeruru/mimiuchi/assets/117558001/16f57820-3a68-42af-bfcc-df12461114ae" />
        </td>
    </tr>
</table>

---

#### Fix being only able to use the last declared trigger phrase

Problem: If a _param trigger_ has multiple _trigger phrases_, only the most recent/last trigger phrase could be used (e.g., in the case of "Apple", "Banana", "Orange", only "Orange" could be used).

Solution: Checks for a _trigger phrase_ now stop as soon as a match is found instead of losing the match to an overwrite.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [X] New Feature
- [ ] Documentation update
- [X] Other
