### PR TITLE
implement SpeechRecognitionErrorEvent handling

### DIFF
--- a/src/modules/speech/WebSpeech.ts
+++ b/src/modules/speech/WebSpeech.ts
@@ -21,13 +21,16 @@ class WebSpeech {
 
   talking: boolean = false
   listening: boolean = false
-  listening_error: boolean = false
 
   speechStore = useSpeechStore()
 
-  onresult: Function = () => {}
   onend: Function = () => {}
   onerror: Function = () => {}
+  onresult: Function = () => {}
+  onstart: Function = () => {}
+
+  last_error: string | undefined
+  try_restart_interval: ReturnType<typeof setTimeout> | undefined
 
   constructor(lang: string = 'en-US') {
     this.recognition = (this.SpeechRecognition) ? new this.SpeechRecognition() : null
@@ -104,6 +107,7 @@ class WebSpeech {
     }
     this.recognition.onend = () => this.onend()
     this.recognition.onerror = (event: any) => this.onerror(event)
+    this.recognition.onstart = () => this.onstart()
   }
 
   stop() {

--- a/src/plugins/localization/en.ts
+++ b/src/plugins/localization/en.ts
@@ -22,8 +22,16 @@ export default {
   },
   alerts: {
     no_speech: 'Your browser does not support Web Speech API (Speech-to-text).',
-    mic_error: 'Error enabling microphone. You must give permission to use it.',
-    device_in_use: 'Error: device in use by another tab.',
+    speech_recognition_error_event: {
+      aborted: 'Error: Device in use.',
+      audio_capture: 'Error: Audio capture failed.',
+      network: 'Error: Network communication required for completing the recognition failed.',
+      not_allowed: 'Error: You must give permission to use the microphone.',
+      service_not_allowed: 'Error: The speech recognition service cannot be started due to settings or policies.',
+      bad_grammar: 'Error: There was a problem with the SpeechGrammarList.',
+      language_not_supported: 'Error: The speech recognition language is not supported by the browser.',
+      unknown: "Error: An unknown error occurred.",
+    },
     broadcast_error: 'Error enabling broadcast. Make sure the desktop app is running.',
     websocket_error: 'Invalid websocket URL',
     version_mismatch: 'The desktop app has a different version than the web version. Consider updating, as things might break.',

--- a/src/plugins/localization/es.ts
+++ b/src/plugins/localization/es.ts
@@ -20,8 +20,10 @@ export default {
   },
   alerts: {
     no_speech: 'Tu navegador no es compatible con Web Speech API (Voz a Texto).',
-    mic_error: 'Error al habilitar el micrófono. Debes dar permiso para usarlo.',
-    device_in_use: 'Error: El micrófono está siendo usado por otra pestaña',
+    speech_recognition_error_event: {
+      aborted: 'Error: El micrófono está siendo usado por otra pestaña',
+      not_allowed: 'Error al habilitar el micrófono. Debes dar permiso para usarlo.',
+    },
     broadcast_error: 'Error al habilitar la transmisión. Asegúrese de que la aplicación de escritorio se esté ejecutando.',
     websocket_error: 'URL de websocket no válida.',
     version_mismatch: 'La aplicación de escritorio tiene una versión diferente a la versión web. Considere la posibilidad de actualizar, ya que la aplicación puede fallar.',

--- a/src/plugins/localization/ja.ts
+++ b/src/plugins/localization/ja.ts
@@ -22,8 +22,10 @@ export default {
   },
   alerts: {
     no_speech: 'このブラウザはWeb Speech APIをサポートしていません（Speech-to-text）',
-    mic_error: 'マイクのアクセスに失敗しました。許可する必要があります。',
-    device_in_use: 'Error: デバイスが別のブラウザタブで使用中です',
+    speech_recognition_error_event: {
+      aborted: 'Error: デバイスが別のブラウザタブで使用中です',
+      not_allowed: 'マイクのアクセスに失敗しました。許可する必要があります。',
+    },
     broadcast_error: 'ブロードキャストに失敗しました. デスクトップアプリが起動していることを確認してください。',
     websocket_error: 'ウェブソケットのURLが無効です',
     version_mismatch: 'デスクトップ版とウェブアプリ版は別物です。壊れるかもしれないので、アップデートを検討してください。',

--- a/src/plugins/localization/zh.ts
+++ b/src/plugins/localization/zh.ts
@@ -22,8 +22,10 @@ export default {
     },
     alerts: {
       no_speech: '您的浏览器不支持 Web Speech API（语音转文本）。',
-      mic_error: '启用麦克风时发生错误。您需要授予权限。',
-      device_in_use: '错误：设备被另一个标签页使用中。',
+      speech_recognition_error_event: {
+        aborted: '错误：设备被另一个标签页使用中。',
+        not_allowed: '启用麦克风时发生错误。您需要授予权限。',
+      },
       broadcast_error: '启用广播时发生错误。请确保桌面应用正在运行。',
       websocket_error: '无效的 WebSocket URL。',
       version_mismatch: '桌面应用的版本与网页版本不同。建议更新，否则可能会出问题。',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description <!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Problems
- https://github.com/naeruru/mimiuchi/issues/43

Solutions
- Error handling has been implemented for the [SpeechRecognitionErrorEvent errors](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognitionErrorEvent/error).

```mermaid
graph LR
    subgraph unknown
        direction LR
        unknown_A["Display error in snackbar"]
    end

    subgraph language-not-supported
        direction LR
        languagenotsupportedA["Display error in snackbar"]
    end

    subgraph bad-grammar
        direction LR
        badgrammar_A["Make microphone icon red"] --> badgrammar_B["Display error in snackbar"] --> badgrammar_C["Stop listening"]
    end

    subgraph service-not-allowed
        direction LR
        servicenotallowed_A["Make microphone icon red"] --> servicenotallowed_B["Display error in snackbar"] --> servicenotallowed_C["Stop listening"]
    end

    subgraph not-allowed
        direction LR
        notallowed_A["Make microphone icon red"] --> notallowed_B["Display error in snackbar"] --> notallowed_C["Stop listening"]
    end

    subgraph network
        direction LR
        network_A["Display error in snackbar"] --> network_B["Stop listening"]
        network_B --> network_C["(onend)<br>Try to restart recognition"]
        network_C --> network_D["(onstart)<br>Clear restart timer"]
        network_D --> network_E["[Network failure]<br>Repeat instructions"]
        network_E --> network_A
        network_D --> network_F["[Network stabilization]<br>No further instructions"]
    end

    subgraph audio-capture
        direction LR
        audiocapture_A["Make microphone icon red"] --> audiocapture_B["Display error in snackbar"] --> audiocapture_C["Stop listening"]
    end

    subgraph aborted
        direction LR
        aborted_A["Make microphone icon red"] --> aborted_B["Display error in snackbar"] --> aborted_C["Stop listening"]
    end

    subgraph no-speech
        direction LR
        nospeech_A[Start listening again]
    end
```

Notes
- Various code has been reorganized to correspond to the order of the property listing [here](https://udn.realityripple.com/docs/Web/API/SpeechRecognition/). This is only aesthetic.
- All code lines referencing the boolean `listening_error` have been deleted.

Concerns
- The boolean `listening_error` in `WebSpeech.ts` seems to be useless.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
